### PR TITLE
feat: implement message limit functionality with commands for setting…

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/SurfChatBukkit.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/SurfChatBukkit.kt
@@ -17,6 +17,7 @@ import dev.slne.surf.chat.core.service.databaseService
 import dev.slne.surf.chat.bukkit.command.channel.ChannelCommand
 import dev.slne.surf.chat.core.service.blacklistService
 import dev.slne.surf.chat.core.service.chatMotdService
+import dev.slne.surf.chat.core.service.filterService
 import dev.slne.surf.surfapi.core.api.util.toObjectSet
 import it.unimi.dsi.fastutil.objects.ObjectSet
 
@@ -63,11 +64,13 @@ class SurfChatBukkit(): SuspendingJavaPlugin() {
         databaseService.connect()
         blacklistService.fetch()
         chatMotdService.loadMotd()
+        filterService.loadMessageLimit()
         LuckPermsExtension.loadApi()
     }
 
     override suspend fun onDisableAsync() {
         chatMotdService.saveMotd()
+        filterService.saveMessageLimit()
     }
 
     fun getTeamMembers(): ObjectSet<Player> = Bukkit.getOnlinePlayers().filter { it.hasPermission("surf.chat.command.teamchat") }.toObjectSet()

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/SurfChatCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/SurfChatCommand.kt
@@ -4,6 +4,7 @@ import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.kotlindsl.subcommand
 import dev.slne.surf.chat.bukkit.command.blacklist.BlackListCommand
 import dev.slne.surf.chat.bukkit.command.chatmotd.ChatMotdCommand
+import dev.slne.surf.chat.bukkit.command.messagelimit.MessageLimitCommand
 
 class SurfChatCommand(commandName: String) : CommandAPICommand(commandName) {
     init {
@@ -15,5 +16,6 @@ class SurfChatCommand(commandName: String) : CommandAPICommand(commandName) {
         subcommand(SurfChatLookupCommand("lookup"))
         subcommand(ChatMotdCommand("chatMotd"))
         subcommand(BlackListCommand("blacklist"))
+        subcommand(MessageLimitCommand("messageLimit"))
     }
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/messagelimit/MessageLimitCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/messagelimit/MessageLimitCommand.kt
@@ -1,0 +1,12 @@
+package dev.slne.surf.chat.bukkit.command.messagelimit
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.subcommand
+
+class MessageLimitCommand(commandName: String): CommandAPICommand(commandName) {
+    init {
+        withPermission("surf.chat.command.messagelimit")
+        subcommand(MessageLimitSetCommand("setLimit"))
+        subcommand(MessageLimitInfoCommand("info"))
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/messagelimit/MessageLimitInfoCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/messagelimit/MessageLimitInfoCommand.kt
@@ -1,0 +1,22 @@
+package dev.slne.surf.chat.bukkit.command.messagelimit
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.api.surfChatApi
+import dev.slne.surf.chat.core.service.filterService
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+
+class MessageLimitInfoCommand(commandName: String): CommandAPICommand(commandName) {
+    init {
+        playerExecutor { player, _ ->
+            val limit = filterService.getMessageLimit()
+
+            surfChatApi.sendText(player, buildText {
+                primary("Das Nachrichten Limit ist auf ")
+                variableValue("${limit.first}/${limit.second} mps (${limit.first} Nachrichten in ${limit.second} Sekunden)")
+                success(" gesetzt.")
+            })
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/messagelimit/MessageLimitSetCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/messagelimit/MessageLimitSetCommand.kt
@@ -1,0 +1,28 @@
+package dev.slne.surf.chat.bukkit.command.messagelimit
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.integerArgument
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.slne.surf.chat.api.surfChatApi
+import dev.slne.surf.chat.core.service.filterService
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+
+class MessageLimitSetCommand(commandName: String) : CommandAPICommand(commandName) {
+    init {
+        integerArgument("messages")
+        integerArgument("seconds")
+
+        playerExecutor { player, args ->
+            val messages: Int by args
+            val seconds: Int by args
+
+            filterService.setMessageLimit(seconds, messages)
+            surfChatApi.sendText(player, buildText {
+                primary("Das Nachrichten Limit wurde auf ")
+                variableValue("$messages/$seconds mps")
+                success(" gesetzt.")
+            })
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
@@ -27,7 +27,7 @@ class BukkitChatListener(): Listener {
             ChatMessageType.GLOBAL,
             "N/A",
             messageID,
-            false
+            true
         )
 
         Bukkit.getOnlinePlayers().forEach {
@@ -49,7 +49,7 @@ class BukkitChatListener(): Listener {
                     ChatMessageType.GLOBAL,
                     "N/A",
                     messageID,
-                    true
+                    false
                 )
             }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
@@ -31,8 +31,6 @@ class BukkitChatFormat: ChatFormatModel {
     ): Component {
         return when(messageType) {
             ChatMessageType.GLOBAL -> {
-
-                debug("1")
                 buildText {
                     append(components.getDeleteComponent(messageID, viewer))
                     append(components.getTeleportComponent(sender.name, viewer))
@@ -137,12 +135,14 @@ class BukkitChatFormat: ChatFormatModel {
     }
 
     private fun Component.parseItemPlaceholder(player: Player, warn: Boolean): Component {
-        return this.replaceText(TextReplacementConfig.builder()
-            .matchLiteral("[item]")
-            .replacement(player.getItemComponent(warn))
-            .build()
-        )
+        return this
     }
+
+    //.replaceText(TextReplacementConfig.builder()
+    //            .matchLiteral("[item]")
+    //            .replacement(player.getItemComponent(warn))
+    //            .build()
+    //        )
 
     private fun Player.getItemComponent(warn: Boolean): Component = buildText {
         val stack = inventory.itemInMainHand

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitFilterService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitFilterService.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.chat.bukkit.service
 
 import com.google.auto.service.AutoService
 import dev.slne.surf.chat.api.type.MessageValidationResult
+import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.bukkit.util.toPlainText
 import dev.slne.surf.chat.core.service.FilterService
 import dev.slne.surf.chat.core.service.blacklistService
@@ -80,5 +81,20 @@ class BukkitFilterService : FilterService, Fallback {
 
     override fun getMessageLimit(): Pair<Int, Int> {
         return messageLimitCount to messageLimitSeconds
+    }
+
+    override fun loadMessageLimit() {
+        val config = plugin.config
+        messageLimitSeconds = config.getInt("spam-protection.in-seconds", 10)
+        messageLimitCount = config.getInt("spam-protection.max-messages", 5)
+    }
+
+    override fun saveMessageLimit() {
+        val config = plugin.config
+
+        config.set("spam-protection.in-seconds", messageLimitSeconds)
+        config.set("spam-protection.max-messages", messageLimitCount)
+
+        plugin.saveConfig()
     }
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitFilterService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitFilterService.kt
@@ -10,65 +10,75 @@ import net.kyori.adventure.text.Component
 import net.kyori.adventure.util.Services.Fallback
 import org.bukkit.entity.Player
 import java.util.*
-import kotlin.time.Duration.Companion.seconds
-
-private const val MESSAGE_LIMIT = 5
 
 @AutoService(FilterService::class)
-class BukkitFilterService(): FilterService, Fallback {
+class BukkitFilterService : FilterService, Fallback {
     private val allowedDomains = mutableObjectSetOf<String>()
-    private val rateLimit = mutableObject2LongMapOf<UUID>().apply { defaultReturnValue(0) }.synchronize()
-    private val messageCount = mutableObject2IntMapOf<UUID>().apply { defaultReturnValue(0) }.synchronize()
+
+    private val messageTimestamps = mutableMapOf<UUID, MutableList<Long>>()
+
     private val validCharactersRegex = "^[a-zA-Z0-9/.:_,()%&=?!<>|#^\"²³+*~\\-äöü@\\[\\] ]*$".toRegex()
     private val urlRegex = "((http|https|ftp)://)?([\\w-]+\\.)+[\\w-]+(/[\\w- ./?%&=]*)?".toRegex(RegexOption.IGNORE_CASE)
 
+    private var messageLimitSeconds = 10
+    private var messageLimitCount = 5
+
     override fun find(message: Component, sender: Player): MessageValidationResult {
-        if(sender.hasPermission("surf.chat.filter.bypass")) {
+        if (sender.hasPermission("surf.chat.filter.bypass")) {
             return MessageValidationResult.SUCCESS
         }
 
-
-        if(blacklistService.hasBlackListed(message)) {
+        if (blacklistService.hasBlackListed(message)) {
             return MessageValidationResult.FAILED_BLACKLIST
         }
 
-        if(containsLink(message)) {
+        if (containsLink(message)) {
             return MessageValidationResult.FAILED_BAD_LINK
         }
 
-        if(!isValidInput(message)) {
+        if (!isValidInput(message)) {
             return MessageValidationResult.FAILED_BAD_CHARACTER
         }
 
-        if(isSpamming(sender.uniqueId)) {
+        if (isSpamming(sender.uniqueId)) {
             return MessageValidationResult.FAILED_SPAM
         }
 
         return MessageValidationResult.SUCCESS
     }
 
-    private fun containsLink(message: Component): Boolean {
+    override fun containsLink(message: Component): Boolean {
         return urlRegex.findAll(message.toPlainText()).any { result ->
             val domain = result.groupValues.getOrNull(3) ?: return@any false
             allowedDomains.none { domain.endsWith(it) }
         }
     }
 
-    private fun isValidInput(input: Component): Boolean {
+    override fun isValidInput(input: Component): Boolean {
         return validCharactersRegex.matches(input.toPlainText())
     }
 
-    private fun isSpamming(uuid: UUID): Boolean {
+    override fun isSpamming(uuid: UUID): Boolean {
         val currentTime = System.currentTimeMillis()
-        val lastMessageTime = rateLimit.getLong(uuid)
-        val count = messageCount.getInt(uuid)
+        val windowStart = currentTime - messageLimitSeconds * 1000
+        val timestamps = messageTimestamps.getOrPut(uuid) { mutableListOf() }
 
-        return if (currentTime - lastMessageTime < 10.seconds.inWholeMilliseconds) {
-            (count >= MESSAGE_LIMIT).also { if (!it) messageCount[uuid] = count + 1 }
-        } else {
-            rateLimit[uuid] = currentTime
-            messageCount[uuid] = 1
-            false
+        timestamps.removeIf { it < windowStart }
+
+        if (timestamps.size >= messageLimitCount) {
+            return true
         }
+
+        timestamps.add(currentTime)
+        return false
+    }
+
+    override fun setMessageLimit(seconds: Int, count: Int) {
+        messageLimitSeconds = seconds
+        messageLimitCount = count
+    }
+
+    override fun getMessageLimit(): Pair<Int, Int> {
+        return messageLimitCount to messageLimitSeconds
     }
 }

--- a/surf-chat-bukkit/src/main/resources/config.yml
+++ b/surf-chat-bukkit/src/main/resources/config.yml
@@ -10,3 +10,7 @@ chat-message-of-the-day:
     - " "
     - " "
     - "<dark_gray>*--------------------------------------------------*"
+
+spam-protection:
+  max-messages: 5
+  in-seconds: 1

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/FilterService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/FilterService.kt
@@ -23,6 +23,9 @@ interface FilterService {
     fun setMessageLimit(seconds: Int, count: Int)
     fun getMessageLimit(): Pair<Int, Int>
 
+    fun loadMessageLimit()
+    fun saveMessageLimit()
+
     companion object {
         val INSTANCE = requiredService<FilterService>()
     }

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/FilterService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/FilterService.kt
@@ -4,6 +4,7 @@ import dev.slne.surf.chat.api.type.MessageValidationResult
 import dev.slne.surf.surfapi.core.api.util.requiredService
 import net.kyori.adventure.text.Component
 import org.bukkit.entity.Player
+import java.util.UUID
 
 interface FilterService {
     /**
@@ -14,6 +15,13 @@ interface FilterService {
      * @return The validation error if the message is invalid, or MessageValidationError.SUCCESS if the message is valid.
      */
     fun find(message: Component, sender: Player): MessageValidationResult
+
+    fun containsLink(message: Component): Boolean
+    fun isValidInput(input: Component): Boolean
+    fun isSpamming(uuid: UUID): Boolean
+
+    fun setMessageLimit(seconds: Int, count: Int)
+    fun getMessageLimit(): Pair<Int, Int>
 
     companion object {
         val INSTANCE = requiredService<FilterService>()


### PR DESCRIPTION
This pull request introduces a new message limit feature to the surf-chat-bukkit plugin, along with some related refactoring and configuration updates. The most important changes include adding new commands for setting and retrieving message limits, updating the filter service to handle message limits, and making some adjustments to existing classes.

### New message limit feature:

* **New commands added:**
  - [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/SurfChatCommand.kt`](diffhunk://#diff-0bbe1bc9c2ff4c0e98075dc9b2a7d48c34d4e8b0b4121fba2bc49ebb84380357R7): Added `MessageLimitCommand` to the list of subcommands. [[1]](diffhunk://#diff-0bbe1bc9c2ff4c0e98075dc9b2a7d48c34d4e8b0b4121fba2bc49ebb84380357R7) [[2]](diffhunk://#diff-0bbe1bc9c2ff4c0e98075dc9b2a7d48c34d4e8b0b4121fba2bc49ebb84380357R19)
  - [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/messagelimit/MessageLimitCommand.kt`](diffhunk://#diff-b370b3cb052e91b10aa9ac4df54c731b3959b6676dc3abb3fcfbf4ec3b571786R1-R12): Implemented `MessageLimitCommand` with subcommands `setLimit` and `info`.
  - [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/messagelimit/MessageLimitInfoCommand.kt`](diffhunk://#diff-32ffbeed69e042221bfd4650b529a77d60581984575766510ab1502b5ee213cbR1-R22): Implemented `MessageLimitInfoCommand` to display the current message limit.
  - [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/messagelimit/MessageLimitSetCommand.kt`](diffhunk://#diff-1b6e310fe6e25a8d502073e57bc442633f70c314cdabda94a1e991d68a1097dcR1-R28): Implemented `MessageLimitSetCommand` to set new message limits.

* **Filter service updates:**
  - [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitFilterService.kt`](diffhunk://#diff-d9e081cfd166b6f9d8308b575eaff33ad8a97ca7cff439de4f3e6f5bd9fd7c5fL13-L30): Refactored to use a list of timestamps for message rate limiting, added methods for setting and getting message limits, and exposed additional methods in the `FilterService` interface. [[1]](diffhunk://#diff-d9e081cfd166b6f9d8308b575eaff33ad8a97ca7cff439de4f3e6f5bd9fd7c5fL13-L30) [[2]](diffhunk://#diff-d9e081cfd166b6f9d8308b575eaff33ad8a97ca7cff439de4f3e6f5bd9fd7c5fL50-R82)
  - [`surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/FilterService.kt`](diffhunk://#diff-936a57f67fa5b2178d527908c4b920b5a7503fc01542f9b03471170b51b58a35R7): Updated the `FilterService` interface to include methods for message limit handling. [[1]](diffhunk://#diff-936a57f67fa5b2178d527908c4b920b5a7503fc01542f9b03471170b51b58a35R7) [[2]](diffhunk://#diff-936a57f67fa5b2178d527908c4b920b5a7503fc01542f9b03471170b51b58a35R19-R25)

### Configuration updates:

* [`surf-chat-bukkit/src/main/resources/config.yml`](diffhunk://#diff-7a9e590752d7cd933171a0178008c71815d44f90c3d6c08def60fa19143d510dR13-R16): Added configuration options for spam protection, including maximum messages and time window in seconds.

### Other adjustments:

* **Bug fixes and refactoring:**
  - [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt`](diffhunk://#diff-0e0dc6039f6c5afbea5c70a331f599a39868a770264596c3f2f63641d341cc37L30-R30): Fixed boolean values in chat message handling. [[1]](diffhunk://#diff-0e0dc6039f6c5afbea5c70a331f599a39868a770264596c3f2f63641d341cc37L30-R30) [[2]](diffhunk://#diff-0e0dc6039f6c5afbea5c70a331f599a39868a770264596c3f2f63641d341cc37L52-R52)
  - [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt`](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL34-L35): Removed debug statements and commented out unused code. [[1]](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL34-L35) [[2]](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL140-R146)