### PR TITLE
Fix/fix channel system

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChannelArgument.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChannelArgument.kt
@@ -9,7 +9,7 @@ import dev.slne.surf.chat.core.service.channelService
 
 class ChannelArgument(nodeName: String): CustomArgument<ChannelModel, String>(StringArgument(nodeName), {
     info -> channelService.getChannel(info.input) ?: throw CustomArgumentException.fromMessageBuilder(
-            MessageBuilder("Unknown channel: ").appendArgInput()
+            MessageBuilder("Der Kanal ${info.input} existiert nicht oder ist nicht für dich zugänglich.")
         )
     }) {
     init {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChannelMembersArgument.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChannelMembersArgument.kt
@@ -9,15 +9,17 @@ import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 
 class ChannelMembersArgument(nodeName: String) : CustomArgument<Player, String>(StringArgument(nodeName), { info ->
-            val player = Bukkit.getPlayer(info.input()) ?: throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Der Spieler ${info.input} wurde nicht gefunden."))
-            val channel = channelService.getChannel(player) ?: throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Der Spieler ist in keinem Kanal."))
+    val target = Bukkit.getPlayer(info.input()) ?: throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Der Spieler ${info.input} wurde nicht gefunden."))
+    val player = info.sender as? Player ?: throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Dieser Befehl kann nur von einem Spieler ausgeführt werden."))
 
-            if (!channel.isMember(player)) {
-                throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Der Spieler ${player.name} ist kein Mitglied in deinem Nachrichtenkanal."))
-            }
+    val channel = channelService.getChannel(player) ?: throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Du bist in keinem Kanal."))
 
-            player
-        }) {
+    if (!channel.isMember(target)) {
+        throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Der Spieler ${target.name} ist kein Mitglied in deinem Nachrichtenkanal."))
+    }
+
+    target
+}) {
     init {
         this.replaceSuggestions(ArgumentSuggestions.stringCollection { info ->
             val channel = channelService.getChannel(info.sender) ?: return@stringCollection emptyObjectSet()

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChannelMembersArgument.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChannelMembersArgument.kt
@@ -10,7 +10,7 @@ import org.bukkit.entity.Player
 
 class ChannelMembersArgument(nodeName: String) : CustomArgument<Player, String>(StringArgument(nodeName), { info ->
             val player = Bukkit.getPlayer(info.input()) ?: throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Der Spieler ${info.input} wurde nicht gefunden."))
-            val channel = channelService.getChannel(player) ?: throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Du bist in keinem Kanal, oder dieser ist invalid."))
+            val channel = channelService.getChannel(player) ?: throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Der Spieler ist in keinem Kanal."))
 
             if (!channel.isMember(player)) {
                 throw CustomArgumentException.fromMessageBuilder(MessageBuilder("Der Spieler ${player.name} ist kein Mitglied in deinem Nachrichtenkanal."))

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelBanCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelBanCommand.kt
@@ -44,6 +44,7 @@ class ChannelBanCommand(commandName: String) : CommandAPICommand(commandName) {
                         info("mit Moderator-Rechten")
                         error(" bannen.")
                     })
+                    return@launch
                 }
 
                 channel.ban(targetUser)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelBanCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelBanCommand.kt
@@ -38,6 +38,14 @@ class ChannelBanCommand(commandName: String) : CommandAPICommand(commandName) {
                     return@launch
                 }
 
+                if(channel.isModerator(targetUser) && channel.isModerator(user)) {
+                    user.sendText(buildText {
+                        error("Du kannst keine Spieler ")
+                        info("mit Moderator-Rechten")
+                        error(" bannen.")
+                    })
+                }
+
                 channel.ban(targetUser)
 
                 user.sendText(buildText {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelCreateCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelCreateCommand.kt
@@ -23,6 +23,7 @@ class ChannelCreateCommand(commandName: String) : CommandAPICommand(commandName)
                     user.sendText(buildText {
                         error("Du bist bereits in einem Nachrichtenkanal.")
                     })
+                    return@launch
                 }
 
                 if(channelService.getChannel(name) != null) {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelDemoteCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelDemoteCommand.kt
@@ -48,7 +48,17 @@ class ChannelDemoteCommand(commandName: String) : CommandAPICommand(commandName)
                     return@launch
                 }
 
+                if(channel.isMember(targetUser)) {
+                    user.sendText(buildText {
+                        error("Der Spieler ")
+                        info(target.name)
+                        error(" ist bereits ein Mitglied.")
+                    })
+                    return@launch
+                }
+
                 channel.demote(targetUser)
+
                 user.sendText(buildText {
                     primary("Du hast ")
                     info(target.name)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelDemoteCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelDemoteCommand.kt
@@ -48,7 +48,7 @@ class ChannelDemoteCommand(commandName: String) : CommandAPICommand(commandName)
                     return@launch
                 }
 
-                if(channel.isMember(targetUser)) {
+                if(!channel.isModerator(targetUser) && !channel.isOwner(targetUser)) {
                     user.sendText(buildText {
                         error("Der Spieler ")
                         info(target.name)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelJoinCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelJoinCommand.kt
@@ -41,6 +41,15 @@ class ChannelJoinCommand(commandName: String) : CommandAPICommand(commandName) {
                     return@launch
                 }
 
+                if(channel.isBanned(user)) {
+                    user.sendText(
+                        buildText {
+                            error("Du bist von diesem Nachrichtenkanal ausgeschlossen.")
+                        }
+                    )
+                    return@launch
+                }
+
 
                 channel.join(user)
                 user.sendText(

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelJoinCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelJoinCommand.kt
@@ -22,7 +22,7 @@ class ChannelJoinCommand(commandName: String) : CommandAPICommand(commandName) {
                 val user = databaseService.getUser(player.uniqueId)
 
                 if(channel.status != ChannelStatusType.PUBLIC && !channel.isInvited(user)) {
-                    user.sendText(
+                    user.sendText (
                         buildText {
                             error("Der Nachrichtenkanal ")
                             info(channel.name)
@@ -33,7 +33,7 @@ class ChannelJoinCommand(commandName: String) : CommandAPICommand(commandName) {
                 }
 
                 if (channelService.getChannel(player) != null) {
-                    user.sendText(
+                    user.sendText (
                         buildText {
                             error("Du bist bereits in einem Nachrichtenkanal.")
                         }
@@ -42,7 +42,7 @@ class ChannelJoinCommand(commandName: String) : CommandAPICommand(commandName) {
                 }
 
                 if(channel.isBanned(user)) {
-                    user.sendText(
+                    user.sendText (
                         buildText {
                             error("Du bist von diesem Nachrichtenkanal ausgeschlossen.")
                         }
@@ -52,7 +52,7 @@ class ChannelJoinCommand(commandName: String) : CommandAPICommand(commandName) {
 
 
                 channel.join(user)
-                user.sendText(
+                user.sendText (
                     buildText {
                         primary("Du bist dem Nachrichtenkanal ")
                         info(channel.name)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelKickCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelKickCommand.kt
@@ -39,6 +39,14 @@ class ChannelKickCommand(commandName: String) : CommandAPICommand(commandName) {
                     return@launch
                 }
 
+                if(channel.isModerator(targetUser) && channel.isModerator(user)) {
+                    user.sendText(buildText {
+                        error("Du kannst keine Spieler ")
+                        info("mit Moderator-Rechten")
+                        error(" kicken.")
+                    })
+                }
+
                 channel.kick(targetUser)
                 user.sendText(buildText {
                     primary("Du hast ")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelKickCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelKickCommand.kt
@@ -45,6 +45,7 @@ class ChannelKickCommand(commandName: String) : CommandAPICommand(commandName) {
                         info("mit Moderator-Rechten")
                         error(" kicken.")
                     })
+                    return@launch
                 }
 
                 channel.kick(targetUser)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelLeaveCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelLeaveCommand.kt
@@ -26,10 +26,9 @@ class ChannelLeaveCommand(commandName: String) : CommandAPICommand(commandName) 
                     return@launch
                 }
 
-                channel.leave(user)
-
                 if(channel.isOwner(user)) {
                     val mayBeNextOwner = channel.getMembers()
+                        .filter { it.uuid != user.uuid }
                         .sortedWith(compareBy(
                             { if (channel.isModerator(it)) 0 else 1 },
                             { channel.members[it] }
@@ -40,7 +39,10 @@ class ChannelLeaveCommand(commandName: String) : CommandAPICommand(commandName) 
                         channelService.deleteChannel(channel)
                     } else {
                         channel.transferOwnership(mayBeNextOwner)
+                        channel.leave(user)
                     }
+                } else {
+                    channel.leave(user)
                 }
 
                 user.sendText(buildText {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelPromoteCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelPromoteCommand.kt
@@ -37,6 +37,15 @@ class ChannelPromoteCommand(commandName: String) : CommandAPICommand(commandName
                     return@launch
                 }
 
+                if(channel.isModerator(targetUser)) {
+                    user.sendText(buildText {
+                        error("Der Spieler ")
+                        info(target.name ?: target.uniqueId.toString())
+                        error(" ist bereits Moderator.")
+                    })
+                    return@launch
+                }
+
                 channel.promote(targetUser)
 
                 user.sendText(buildText {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelTransferOwnerShipCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelTransferOwnerShipCommand.kt
@@ -54,7 +54,7 @@ class ChannelTransferOwnerShipCommand(commandName: String) : CommandAPICommand(c
                     user.sendText(buildText {
                         primary("Bitte bestätige die Übertragung des Besitzes des Nachrichtenkanals an ")
                         info(targetUser.getName())
-                        primary(".")
+                        primary(". ")
                         append(components.getTransferConfirmComponent(targetUser.getName()))
                     })
                     return@launch

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelTransferOwnerShipCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelTransferOwnerShipCommand.kt
@@ -17,7 +17,7 @@ import org.bukkit.OfflinePlayer
 class ChannelTransferOwnerShipCommand(commandName: String) : CommandAPICommand(commandName) {
     init {
         withArguments(ChannelMembersArgument("member"))
-        stringArgument("confirm")
+        stringArgument("confirm", optional = true)
         playerExecutor { player, args ->
             val channel: ChannelModel? = channelService.getChannel(player)
             val target = args.getUnchecked<OfflinePlayer>("member") ?: return@playerExecutor

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelUnBanCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelUnBanCommand.kt
@@ -46,7 +46,7 @@ class ChannelUnBanCommand(commandName: String) : CommandAPICommand(commandName) 
                     return@launch
                 }
 
-                channel.unInvite(targetUser)
+                channel.unban(targetUser)
 
                 user.sendText(buildText {
                     primary("Du hast ")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
@@ -5,6 +5,8 @@ import dev.slne.surf.chat.api.surfChatApi
 import dev.slne.surf.chat.api.type.ChatMessageType
 import dev.slne.surf.chat.api.util.history.LoggedMessage
 import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.bukkit.util.sendText
+import dev.slne.surf.chat.core.service.channelService
 import dev.slne.surf.chat.core.service.historyService
 import io.papermc.paper.event.player.AsyncChatEvent
 import org.bukkit.Bukkit
@@ -29,6 +31,28 @@ class BukkitChatListener(): Listener {
             messageID,
             true
         )
+
+        val channel = channelService.getChannel(player)
+
+        if(channel != null) {
+            event.isCancelled = true
+
+            channel.getMembers().forEach {
+                it.sendText(
+                    plugin.chatFormat.formatMessage(
+                        message,
+                        player,
+                        player,
+                        ChatMessageType.CHANNEL,
+                        channel.name,
+                        messageID,
+                        true
+                    )
+                )
+            }
+
+            return
+        }
 
         Bukkit.getOnlinePlayers().forEach {
             historyService.logCaching(it.uniqueId, LoggedMessage(player.name, "Unknown", formattedMessage), messageID)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
@@ -38,11 +38,13 @@ class BukkitChatListener(): Listener {
             true
         )
 
-        val cleanedMessage = message.replaceText(TextReplacementConfig
-            .builder()
-            .match(Pattern.compile("@(?:all|a|here|everyone)\\b\n"))
-            .replacement(Component.empty())
-            .build())
+        val cleanedMessage = message.replaceText(
+            TextReplacementConfig.builder()
+                .match(Pattern.compile("^@(all|a|here|everyone)\\b\\s*", Pattern.CASE_INSENSITIVE))
+                .replacement(Component.empty())
+                .build()
+        )
+
 
         Bukkit.getOnlinePlayers().forEach {
             historyService.logCaching(it.uniqueId, LoggedMessage(player.name, "Unknown", formattedMessage), messageID)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
@@ -69,6 +69,8 @@ class BukkitChatListener(): Listener {
                 surfChatApi.logMessage(player.uniqueId, ChatMessageType.CHANNEL, message, messageID)
             }
 
+            event.isCancelled = true
+
             return
         }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitChannelService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitChannelService.kt
@@ -88,6 +88,7 @@ class BukkitChannelService(): ChannelService, Fallback {
 
             if(channel.isOwner(user)) {
                 val mayBeNextOwner = channel.getMembers()
+                    .filter { it.uuid != user.uuid }
                     .sortedWith(compareBy(
                         { if (channel.isModerator(it)) 0 else 1 },
                         { channel.members[it] }
@@ -98,11 +99,11 @@ class BukkitChannelService(): ChannelService, Fallback {
                     channelService.deleteChannel(channel)
                 } else {
                     channel.transferOwnership(mayBeNextOwner)
+                    channel.leave(user)
                 }
-                return@launch
+            } else {
+                channel.leave(user)
             }
-
-            channel.leave(user)
         }
     }
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitChannelService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitChannelService.kt
@@ -63,14 +63,19 @@ class BukkitChannelService(): ChannelService, Fallback {
     }
 
     override fun move(player: Player, channel: ChannelModel) {
-        val currentChannel = channelService.getChannel(player) ?: return
-
-        if (currentChannel == channel) {
-            return
-        }
+        val currentChannel = channelService.getChannel(player)
 
         plugin.launch {
-            currentChannel.leave(player.toChatUser())
+            val user = player.toChatUser()
+
+            if(currentChannel != null)  {
+                if (currentChannel == channel) {
+                    return@launch
+                }
+
+                currentChannel.leave(user)
+            }
+
             channel.join(player.toChatUser())
         }
     }


### PR DESCRIPTION
This pull request includes several updates and improvements to the `surf-chat-bukkit` module, focusing on enhancing command handling and channel management. The key changes involve improving error messages, adding new checks for command executions, and modifying the behavior of certain commands to ensure proper functionality.

### Command Handling Improvements:

* [`ChannelArgument.kt`](diffhunk://#diff-fcb152fdf9daccf4484615c2991665155649a39f76bbb52fd80feb43bbd04478L12-R12): Updated the error message to be more informative when a channel is not found or accessible.
* [`ChannelMembersArgument.kt`](diffhunk://#diff-c73b53e81cae8fd273ca43e0019e3c24af3394dc4adcb18ff6535a4f37969f1bL12-R21): Added checks to ensure the command is executed by a player and improved error handling for player and channel membership validation.

### Channel Management Enhancements:

* [`ChannelBanCommand.kt`](diffhunk://#diff-a08f439552c547190508807801773fe8d2d33b4862f95d2a48bad2edd3b87171R41-R49): Prevented moderators from banning other moderators, with a clear error message.
* [`ChannelKickCommand.kt`](diffhunk://#diff-c61f2416c2e7045c1e0cdf3a1f472ed0ca7cea637e219b6f8efcbcf1588c588dR42-R50): Added a check to prevent moderators from kicking other moderators, with a clear error message.
* [`ChannelPromoteCommand.kt`](diffhunk://#diff-dd4227ac9093ef9befe45f84bb969582e38cfed4b080a4872bce87ad11b26594R40-R48): Added a check to prevent promoting a player who is already a moderator, with a clear error message.
* [`ChannelDemoteCommand.kt`](diffhunk://#diff-d7f115bb3a38c8472b2953e92a5ec89153b4a4105d8e35d179ef19bc2fd11983R51-R61): Added a check to prevent demoting a player who is not a moderator or owner, with a clear error message.

### Additional Command Adjustments:

* [`ChannelJoinCommand.kt`](diffhunk://#diff-d62b7dce82bb3b72262bb172cf9ab534d3dfd05f390a49c6af0bedeb4f858589R44-R52): Added a check to prevent banned users from joining a channel, with a clear error message.
* [`ChannelLeaveCommand.kt`](diffhunk://#diff-6c837650de19a1a11460c48d7cea5b11b53b80c0369774d94bf4e22498fc65aaR42-R45): Ensured proper handling of channel ownership transfer or deletion when a user leaves a channel.
* [`ChannelTransferOwnerShipCommand.kt`](diffhunk://#diff-cbf5f786d2b2ae85c7c2e851962a139e1c0a5f82257b807d4c9c023a7e1ac640L20-R20): Made the "confirm" argument optional for the command.
* [`ChannelUnBanCommand.kt`](diffhunk://#diff-00e1b971f68cc43d21673c2596ab365746e0baa4658e460108350f504ab3a6b8L49-R49): Corrected the method call from `unInvite` to `unban` for unbanning users.

### Chat Listener and Service Updates:

* [`BukkitChatListener.kt`](diffhunk://#diff-0e0dc6039f6c5afbea5c70a331f599a39868a770264596c3f2f63641d341cc37R41-R88): Added functionality to clean messages and handle channel-specific messages separately from global messages.
* [`BukkitChannelService.kt`](diffhunk://#diff-b03283852c0b6cf0613718594e3d6f4c052f600837edff40af186f0e1ce68e0aR102-R109): Improved the `move` method to handle channel leaving and joining more effectively, ensuring proper channel ownership transfer or deletion.

Fixes #3