### PR TITLE
fix: fix player-name pings & highlights

### DIFF
--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/model/ChatUserModel.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/model/ChatUserModel.kt
@@ -9,6 +9,7 @@ interface ChatUserModel {
 
     val ignoreList: ObjectArraySet<UUID>
     var pmToggled: Boolean
+    val likesSound: Boolean
 
     fun isIgnoring(target: UUID): Boolean
     fun ignore(target: UUID)

--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/model/ChatUserModel.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/model/ChatUserModel.kt
@@ -9,12 +9,14 @@ interface ChatUserModel {
 
     val ignoreList: ObjectArraySet<UUID>
     var pmToggled: Boolean
-    val likesSound: Boolean
+    var likesSound: Boolean
 
     fun isIgnoring(target: UUID): Boolean
     fun ignore(target: UUID)
     fun unIgnore(target: UUID)
     fun toggleIgnore(target: UUID): Boolean
+
+    fun toggleSound(): Boolean
 
     fun acceptInvite(channel: ChannelModel)
     fun declineInvite(channel: ChannelModel)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/SurfChatBukkit.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/SurfChatBukkit.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.chat.bukkit
 
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
 import com.google.gson.Gson
+
 import dev.jorel.commandapi.CommandAPI
 
 import dev.slne.surf.chat.api.model.ChatFormatModel
@@ -19,6 +20,7 @@ import dev.slne.surf.chat.core.service.blacklistService
 import dev.slne.surf.chat.core.service.chatMotdService
 import dev.slne.surf.chat.core.service.filterService
 import dev.slne.surf.surfapi.core.api.util.toObjectSet
+
 import it.unimi.dsi.fastutil.objects.ObjectSet
 
 import org.bukkit.Bukkit

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/SurfChatBukkit.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/SurfChatBukkit.kt
@@ -72,6 +72,7 @@ class SurfChatBukkit(): SuspendingJavaPlugin() {
     override suspend fun onDisableAsync() {
         chatMotdService.saveMotd()
         filterService.saveMessageLimit()
+        databaseService.saveAll()
     }
 
     fun getTeamMembers(): ObjectSet<Player> = Bukkit.getOnlinePlayers().filter { it.hasPermission("surf.chat.command.teamchat") }.toObjectSet()

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/SurfChatBukkit.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/SurfChatBukkit.kt
@@ -45,6 +45,7 @@ class SurfChatBukkit(): SuspendingJavaPlugin() {
         PrivateMessageCommand("msg").register()
         ReplyCommand("reply").register()
         TogglePmCommand("togglepm").register()
+        ToggleSoundCommand("togglesound").register()
         TeamChatCommand("teamchat").register()
         BlackListCommand("blacklist").register()
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/TogglePmCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/TogglePmCommand.kt
@@ -11,7 +11,7 @@ import net.kyori.adventure.text.format.TextDecoration
 
 class TogglePmCommand(commandName: String) : CommandAPICommand(commandName) {
     init {
-        withPermission("surf.chat.command.toggle")
+        withPermission("surf.chat.command.toggle.pm")
         playerExecutor { player, _ ->
             plugin.launch {
                 val user = databaseService.getUser(player.uniqueId)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/ToggleSoundCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/ToggleSoundCommand.kt
@@ -25,7 +25,7 @@ class ToggleSoundCommand(commandName: String) : CommandAPICommand(commandName) {
                 } else {
                     user.sendText(buildText {
                         primary("Du hörst jetzt ")
-                        success("keine Notify-Sounds mehr.")
+                        error("keine Notify-Sounds mehr.")
                     })
                 }
             }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/ToggleSoundCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/ToggleSoundCommand.kt
@@ -1,0 +1,34 @@
+package dev.slne.surf.chat.bukkit.command
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.bukkit.util.sendText
+import dev.slne.surf.chat.core.service.databaseService
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import net.kyori.adventure.text.format.TextDecoration
+
+class ToggleSoundCommand(commandName: String) : CommandAPICommand(commandName) {
+    init {
+        withPermission("surf.chat.command.toggle.notify")
+        playerExecutor { player, _ ->
+            plugin.launch {
+                val user = databaseService.getUser(player.uniqueId)
+                val likesSound = user.toggleSound()
+
+                if(likesSound) {
+                    user.sendText(buildText {
+                        primary("Du hörst jetzt ")
+                        success("Notify-Sounds. ")
+                    })
+                } else {
+                    user.sendText(buildText {
+                        primary("Du hörst jetzt ")
+                        success("keine Notify-Sounds mehr.")
+                    })
+                }
+            }
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
@@ -5,19 +5,22 @@ import dev.slne.surf.chat.api.surfChatApi
 import dev.slne.surf.chat.api.type.ChatMessageType
 import dev.slne.surf.chat.bukkit.extension.LuckPermsExtension
 import dev.slne.surf.chat.bukkit.util.components
-import dev.slne.surf.chat.bukkit.util.debug
 import dev.slne.surf.chat.bukkit.util.toPlainText
 import dev.slne.surf.surfapi.core.api.messages.Colors
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import dev.slne.surf.surfapi.core.api.messages.adventure.sound
+
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.TextReplacementConfig
 import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.minimessage.MiniMessage
+
 import org.bukkit.Bukkit
 import org.bukkit.Material
+import org.bukkit.Sound
 import org.bukkit.entity.Player
+
 import java.util.UUID
-import java.util.regex.Pattern
 
 class BukkitChatFormat: ChatFormatModel {
     override fun formatMessage (
@@ -36,7 +39,7 @@ class BukkitChatFormat: ChatFormatModel {
                     append(components.getTeleportComponent(sender.name, viewer))
                     append(MiniMessage.miniMessage().deserialize(LuckPermsExtension.getPrefix(sender) + sender.name))
                     darkSpacer(" >> ")
-                    append(rawMessage)
+                    append(highlightPlayers(rawMessage))
                 }.parseItemPlaceholder(sender, warn)
             }
 
@@ -45,7 +48,7 @@ class BukkitChatFormat: ChatFormatModel {
                     append(MiniMessage.miniMessage().deserialize(LuckPermsExtension.getPrefix(sender) + sender.name))
                     darkSpacer(" >> ")
                     append(components.getChannelComponent(channel))
-                    append(rawMessage)
+                    append(highlightPlayers(rawMessage))
                 }.parseItemPlaceholder(sender, warn)
             }
 
@@ -176,19 +179,29 @@ class BukkitChatFormat: ChatFormatModel {
         var message = rawMessage
 
         for (onlinePlayer in Bukkit.getOnlinePlayers()) {
-            if(!message.contains(Component.text(onlinePlayer.name))) {
-                continue
-            }
+            val name = onlinePlayer.name
+            val pattern = Regex("(?<!\\w)@?$name(?!\\w)")
+
+            if (!pattern.containsMatchIn(message.toPlainText())) continue
+
+            onlinePlayer.playSound(sound {
+                type(Sound.AMBIENT_CAVE)
+                source(net.kyori.adventure.sound.Sound.Source.PLAYER)
+                volume(1f)
+                pitch(1f)
+            })
 
             message = message.replaceText(TextReplacementConfig
                 .builder()
-                .match(Pattern.quote(onlinePlayer.name))
+                .match(pattern.pattern)
                 .replacement(buildText {
-                    variableValue(onlinePlayer.name)
+                    variableValue(name)
+                    decorate(TextDecoration.BOLD)
                 })
                 .build())
         }
 
         return message
     }
+
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
@@ -195,7 +195,7 @@ class BukkitChatFormat: ChatFormatModel {
                 .builder()
                 .match(pattern.pattern)
                 .replacement(buildText {
-                    variableValue(name)
+                    append(Component.text(name))
                     decorate(TextDecoration.BOLD)
                 })
                 .build())

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
@@ -187,8 +187,8 @@ class BukkitChatFormat: ChatFormatModel {
             onlinePlayer.playSound(sound {
                 type(Sound.BLOCK_NOTE_BLOCK_PLING)
                 source(net.kyori.adventure.sound.Sound.Source.PLAYER)
-                volume(1f)
-                pitch(1f)
+                volume(0.25f)
+                pitch(2f)
             })
 
             message = message.replaceText(TextReplacementConfig

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
@@ -1,11 +1,14 @@
 package dev.slne.surf.chat.bukkit.model
 
+import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.chat.api.model.ChatFormatModel
 import dev.slne.surf.chat.api.surfChatApi
 import dev.slne.surf.chat.api.type.ChatMessageType
 import dev.slne.surf.chat.bukkit.extension.LuckPermsExtension
+import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.bukkit.util.components
 import dev.slne.surf.chat.bukkit.util.toPlainText
+import dev.slne.surf.chat.core.service.databaseService
 import dev.slne.surf.surfapi.core.api.messages.Colors
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import dev.slne.surf.surfapi.core.api.messages.adventure.sound
@@ -167,14 +170,6 @@ class BukkitChatFormat: ChatFormatModel {
         hoverEvent(stack.asHoverEvent())
     }
 
-
-    /**
-     *
-     * This method is currently not implemented.
-     * It has to be fixed
-     * With many players online, it could produce some performance issues.
-     *
-     */
     private fun highlightPlayers(rawMessage: Component): Component {
         var message = rawMessage
 
@@ -184,12 +179,20 @@ class BukkitChatFormat: ChatFormatModel {
 
             if (!pattern.containsMatchIn(message.toPlainText())) continue
 
-            onlinePlayer.playSound(sound {
-                type(Sound.BLOCK_NOTE_BLOCK_PLING)
-                source(net.kyori.adventure.sound.Sound.Source.PLAYER)
-                volume(0.25f)
-                pitch(2f)
-            })
+            plugin.launch {
+                val user = databaseService.getUser(onlinePlayer.uniqueId)
+
+                if(user.likesSound) {
+                    onlinePlayer.playSound(sound {
+                        type(Sound.BLOCK_NOTE_BLOCK_PLING)
+                        source(net.kyori.adventure.sound.Sound.Source.PLAYER)
+                        volume(0.25f)
+                        pitch(2f)
+                    })
+                }
+            }
+
+
 
             message = message.replaceText(TextReplacementConfig
                 .builder()

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
@@ -185,7 +185,7 @@ class BukkitChatFormat: ChatFormatModel {
             if (!pattern.containsMatchIn(message.toPlainText())) continue
 
             onlinePlayer.playSound(sound {
-                type(Sound.AMBIENT_CAVE)
+                type(Sound.BLOCK_NOTE_BLOCK_PLING)
                 source(net.kyori.adventure.sound.Sound.Source.PLAYER)
                 volume(1f)
                 pitch(1f)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatUser.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatUser.kt
@@ -13,7 +13,7 @@ class BukkitChatUser (
     override val uuid: UUID,
     override val ignoreList: ObjectArraySet<UUID> = ObjectArraySet(),
     override var pmToggled: Boolean = false,
-    override val likesSound: Boolean = false
+    override val likesSound: Boolean = true
 ): ChatUserModel {
     override fun isIgnoring(target: UUID): Boolean {
         return ignoreList.contains(target)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatUser.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatUser.kt
@@ -13,7 +13,7 @@ class BukkitChatUser (
     override val uuid: UUID,
     override val ignoreList: ObjectArraySet<UUID> = ObjectArraySet(),
     override var pmToggled: Boolean = false,
-    override val likesSound: Boolean = true
+    override var likesSound: Boolean = true
 ): ChatUserModel {
     override fun isIgnoring(target: UUID): Boolean {
         return ignoreList.contains(target)
@@ -35,6 +35,11 @@ class BukkitChatUser (
             ignoreList.add(target)
             return true
         }
+    }
+
+    override fun toggleSound(): Boolean {
+        likesSound = !likesSound
+        return likesSound
     }
 
     override fun acceptInvite(channel: ChannelModel) {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatUser.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatUser.kt
@@ -12,7 +12,8 @@ import java.util.*
 class BukkitChatUser (
     override val uuid: UUID,
     override val ignoreList: ObjectArraySet<UUID> = ObjectArraySet(),
-    override var pmToggled: Boolean = false
+    override var pmToggled: Boolean = false,
+    override val likesSound: Boolean = false
 ): ChatUserModel {
     override fun isIgnoring(target: UUID): Boolean {
         return ignoreList.contains(target)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitDatabaseService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitDatabaseService.kt
@@ -268,8 +268,10 @@ class BukkitDatabaseService(): DatabaseService, Fallback {
         }
     }
 
-    override fun saveAll() {
-        dataCache.invalidateAll()
+    override suspend fun saveAll() {
+        dataCache.asMap().forEach {
+            saveUser(it.value)
+        }
     }
 
     override fun getName(uuid: UUID): String {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitDatabaseService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitDatabaseService.kt
@@ -268,6 +268,10 @@ class BukkitDatabaseService(): DatabaseService, Fallback {
         }
     }
 
+    override fun saveAll() {
+        dataCache.invalidateAll()
+    }
+
     override fun getName(uuid: UUID): String {
         return nameCache.get(uuid)
     }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitDatabaseService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitDatabaseService.kt
@@ -54,7 +54,8 @@ class BukkitDatabaseService(): DatabaseService, Fallback {
     object Users : Table() {
         val uuid = varchar("uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
         val ignoreList = text("ignoreList").transform({ gson.fromJson(it, ObjectArraySet<UUID>().javaClass) }, { gson.toJson(it) })
-        val pmToggled = bool("pmToggled")
+        val pmToggled = bool("pmToggled").default(false)
+        val likesSound = bool("likesSound").default(true)
 
         override val primaryKey = PrimaryKey(uuid)
     }
@@ -104,7 +105,8 @@ class BukkitDatabaseService(): DatabaseService, Fallback {
                     BukkitChatUser(
                         uuid = it[Users.uuid],
                         ignoreList = it[Users.ignoreList],
-                        pmToggled = it[Users.pmToggled]
+                        pmToggled = it[Users.pmToggled],
+                        likesSound = it[Users.likesSound]
                     )
                 }
             }
@@ -118,6 +120,7 @@ class BukkitDatabaseService(): DatabaseService, Fallback {
                     it[uuid] = user.uuid
                     it[ignoreList] = user.ignoreList
                     it[pmToggled] = user.pmToggled
+                    it[likesSound] = user.likesSound
                 }
             }
         }

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DatabaseService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DatabaseService.kt
@@ -24,6 +24,8 @@ interface DatabaseService {
 
     suspend fun insertHistoryEntry(user: UUID, entry: HistoryEntryModel)
 
+    fun saveAll()
+
     fun getName(uuid: UUID): String
 
     companion object {

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DatabaseService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DatabaseService.kt
@@ -24,7 +24,7 @@ interface DatabaseService {
 
     suspend fun insertHistoryEntry(user: UUID, entry: HistoryEntryModel)
 
-    fun saveAll()
+    suspend fun saveAll()
 
     fun getName(uuid: UUID): String
 


### PR DESCRIPTION
This pull request includes several changes to the `BukkitChatFormat` class in the `surf-chat-bukkit` module, focusing on improving the functionality of chat message formatting and player highlighting.

### Improvements to chat message formatting:

* [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt`](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL8-L20): Added imports for `sound` and `Sound` to enable playing sounds when a player's name is mentioned in chat.

### Enhancements to player highlighting:

* [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt`](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL39-R42): Replaced the direct appending of `rawMessage` with the `highlightPlayers(rawMessage)` method to highlight player names in chat messages. [[1]](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL39-R42) [[2]](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL48-R51)
* [`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt`](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL179-R206): Updated the player highlighting logic to use a regex pattern for matching player names and added functionality to play a sound when a player's name is mentioned.