### PR TITLE
refactor(history-service): streamline message resending logic and add…

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.kt
@@ -10,6 +10,7 @@ import dev.slne.surf.chat.bukkit.model.BukkitHistoryEntry
 import dev.slne.surf.chat.api.util.history.HistoryPair
 import dev.slne.surf.chat.api.util.history.LoggedMessage
 import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.bukkit.util.player
 import dev.slne.surf.chat.core.service.HistoryService
 import dev.slne.surf.chat.core.service.databaseService
 import dev.slne.surf.surfapi.bukkit.api.util.forEachPlayer
@@ -65,20 +66,17 @@ class BukkitHistoryService(): HistoryService, Fallback {
 
     override fun resendMessages(player: UUID) {
         val chatHistory = historyCache.getIfPresent(player) ?: return
+        val receiver = player(player) ?: return
 
-        forEachPlayer { online ->
-            repeat(100) {
-                online.sendMessage(Component.empty())
-            }
+        repeat(100) {
+            receiver.sendMessage(Component.empty())
         }
 
         chatHistory.object2ObjectEntrySet()
-            .sortedByDescending { it.key.sendTime }
+            .sortedBy { it.key.sendTime }
             .take(25)
             .forEach { (_, value) ->
-                forEachPlayer { player ->
-                    player.sendMessage(value.message)
-                }
+                receiver.sendMessage { value.message }
             }
     }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/chatuser-util.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/chatuser-util.kt
@@ -45,3 +45,11 @@ fun UUID.getUsername(): String {
     val player = Bukkit.getPlayer(this)
     return player?.name ?: "Unknown"
 }
+
+fun player(userName: String): Player? {
+    return Bukkit.getPlayer(userName)
+}
+
+fun player(uuid: UUID): Player? {
+    return Bukkit.getPlayer(uuid)
+}


### PR DESCRIPTION
This pull request refactors the `BukkitHistoryService` class to improve code clarity and efficiency when handling chat history, and introduces utility methods for retrieving players. The most important changes include replacing the use of `forEachPlayer` with a specific player receiver, modifying the sorting order of chat history, and adding utility methods for player retrieval.

### Refactoring in `BukkitHistoryService`:

* Replaced the use of `forEachPlayer` with a specific `receiver` obtained via the new `player(UUID): Player?` utility method, ensuring messages are sent only to the intended recipient. (`[surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.ktR69-R79](diffhunk://#diff-90980bf1b11dbef1e526fbf5b8720d4e11aaa9b8c1e3ba07eb2d709d5d2b043dR69-R79)`)
* Changed the sorting order of chat history from descending to ascending by `sendTime` to align with a chronological display. (`[surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.ktR69-R79](diffhunk://#diff-90980bf1b11dbef1e526fbf5b8720d4e11aaa9b8c1e3ba07eb2d709d5d2b043dR69-R79)`)

### Utility methods for player retrieval:

* Added two new utility functions, `player(userName: String): Player?` and `player(uuid: UUID): Player?`, to simplify player lookup by username or UUID. (`[surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/chatuser-util.ktR48-R55](diffhunk://#diff-3bcb96dadce5fb08c5f5bc1166dc105292cc19fe698da098485f47eefcc81c44R48-R55)`)

### Import updates:

* Added the import statement for `dev.slne.surf.chat.bukkit.util.player` to support the new utility methods. (`[surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.ktR13](diffhunk://#diff-90980bf1b11dbef1e526fbf5b8720d4e11aaa9b8c1e3ba07eb2d709d5d2b043dR13)`)

fixes #22 