### PR TITLE
Feat/add cross server pms

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.kt
@@ -4,27 +4,30 @@ import com.github.shynixn.mccoroutine.folia.launch
 
 import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.arguments.ArgumentSuggestions
-import dev.jorel.commandapi.arguments.PlayerArgument
+import dev.jorel.commandapi.arguments.StringArgument
 import dev.jorel.commandapi.kotlindsl.greedyStringArgument
 import dev.jorel.commandapi.kotlindsl.playerExecutor
 
 import dev.slne.surf.chat.api.surfChatApi
 import dev.slne.surf.chat.api.type.ChatMessageType
 import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.bukkit.service.BukkitMessagingSenderService
 import dev.slne.surf.chat.bukkit.util.sendRawText
 import dev.slne.surf.chat.bukkit.util.sendText
 import dev.slne.surf.chat.bukkit.util.serverPlayers
 import dev.slne.surf.chat.core.service.databaseService
+import dev.slne.surf.chat.core.service.messaging.messagingSenderService
 import dev.slne.surf.chat.core.service.replyService
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 
 import net.kyori.adventure.text.Component
+import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import java.util.*
 
 class PrivateMessageCommand(commandName: String) : CommandAPICommand(commandName) {
     init {
-        withArguments(PlayerArgument("player").replaceSuggestions(ArgumentSuggestions.stringCollection {
+        withArguments(StringArgument("player").replaceSuggestions(ArgumentSuggestions.stringCollection {
             serverPlayers.map { it.name }
         }))
         greedyStringArgument("message")
@@ -33,29 +36,52 @@ class PrivateMessageCommand(commandName: String) : CommandAPICommand(commandName
         withPermission("surf.chat.command.private-message")
         playerExecutor { player, args ->
             plugin.launch {
-                val target = args.getUnchecked<Player>("player") ?: return@launch
+                val target = args.getUnchecked<String>("player") ?: return@launch
                 val message = args.getUnchecked<String>("message") ?: return@launch
                 val messageComponent = Component.text(message)
 
+                val targetPlayer: Player? = Bukkit.getPlayer(target)
                 val user = databaseService.getUser(player.uniqueId)
-                val targetUser = databaseService.getUser(target.uniqueId)
 
-                if(targetUser.uuid == user.uuid) {
+                if(player.name == target) {
                     user.sendText(buildText {
                         error("Du kannst dir nicht selbst eine Nachricht senden.")
                     })
                     return@launch
                 }
 
-                plugin.messageValidator.parse(messageComponent, ChatMessageType.PRIVATE_TO, player) {
-                    targetUser.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, target, ChatMessageType.PRIVATE_FROM, "", UUID.randomUUID(), true))
-                    user.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, target, ChatMessageType.PRIVATE_TO, "", UUID.randomUUID(), true))
+                if(targetPlayer == null) {
+                    plugin.messageValidator.parse(messageComponent, ChatMessageType.PRIVATE_TO, player) {
+                        user.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, player, ChatMessageType.PRIVATE_TO, "", UUID.randomUUID(), true))
 
-                    replyService.updateLast(player.uniqueId, target.uniqueId)
-                    replyService.updateLast(target.uniqueId, player.uniqueId)
+                        plugin.launch {
+                            surfChatApi.logMessage(player.uniqueId, ChatMessageType.PRIVATE_GENERAL, messageComponent, UUID.randomUUID())
+                        }
 
-                    plugin.launch {
-                        surfChatApi.logMessage(player.uniqueId, ChatMessageType.PRIVATE_GENERAL, messageComponent, UUID.randomUUID())
+                        messagingSenderService.sendData (
+                            player.name,
+                            target,
+                            messageComponent,
+                            ChatMessageType.PRIVATE_FROM,
+                            UUID.randomUUID(),
+                            "N/A",
+                            BukkitMessagingSenderService.getForwardingServers()
+                        )
+                    }
+                } else {
+                    val user = databaseService.getUser(player.uniqueId)
+                    val targetUser = databaseService.getUser(targetPlayer.uniqueId)
+
+                    plugin.messageValidator.parse(messageComponent, ChatMessageType.PRIVATE_TO, player) {
+                        targetUser.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, targetPlayer, ChatMessageType.PRIVATE_FROM, "", UUID.randomUUID(), true))
+                        user.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, player, ChatMessageType.PRIVATE_TO, "", UUID.randomUUID(), true))
+
+                        replyService.updateLast(player.uniqueId, targetUser.uuid)
+                        replyService.updateLast(targetUser.uuid, player.uniqueId)
+
+                        plugin.launch {
+                            surfChatApi.logMessage(player.uniqueId, ChatMessageType.PRIVATE_GENERAL, messageComponent, UUID.randomUUID())
+                        }
                     }
                 }
             }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt
@@ -74,7 +74,7 @@ class BukkitChatFormat: ChatFormatModel {
                     darkSpacer(" | ")
                     variableValue("Du")
                     darkSpacer(" -> ")
-                    append(MiniMessage.miniMessage().deserialize(LuckPermsExtension.getPrefix(viewer) + viewer.name))
+                    append(MiniMessage.miniMessage().deserialize(viewer.name))
                     darkSpacer(" >> ")
                     append(formatItemTag(rawMessage, sender, warn))
 
@@ -89,7 +89,7 @@ class BukkitChatFormat: ChatFormatModel {
                     darkSpacer(">> ")
                     append(Component.text("PM", Colors.RED))
                     darkSpacer(" | ")
-                    append(MiniMessage.miniMessage().deserialize(LuckPermsExtension.getPrefix(sender) + sender.name))
+                    append(MiniMessage.miniMessage().deserialize(sender.name))
                     darkSpacer(" -> ")
                     variableValue("Dir")
                     darkSpacer(" >> ")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt
@@ -46,10 +46,32 @@ class BukkitMessagingReceiverService : MessagingReceiverService, PluginMessageLi
         channel: String,
         forwardingServers: ObjectSet<String>
     ) {
-        serverPlayers.forEach {
-            historyService.logCaching(it.uniqueId, LoggedMessage(player, "Unknown", message), messageID)
-        }
+        when(type) {
+            ChatMessageType.GLOBAL -> {
+                serverPlayers.forEach {
+                    historyService.logCaching(it.uniqueId, LoggedMessage(player, target, message), messageID)
+                    it.sendMessage(message)
+                }
+            }
+            ChatMessageType.PRIVATE_FROM -> {
+                val targetPlayer = Bukkit.getPlayer(target) ?: return
 
-        Bukkit.broadcast(message)
+                historyService.logCaching(targetPlayer.uniqueId, LoggedMessage(player, target, message), messageID)
+                targetPlayer.sendMessage(message)
+            }
+
+            ChatMessageType.PRIVATE_TO -> {
+                val targetPlayer = Bukkit.getPlayer(player) ?: return
+
+                historyService.logCaching(targetPlayer.uniqueId, LoggedMessage(player, target, message), messageID)
+                targetPlayer.sendMessage(message)
+            }
+
+            else -> {
+                /**
+                 * Do nothing, other types are not supported
+                 */
+            }
+        }
     }
 }

--- a/surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/service/VelocityMessagingSenderService.kt
+++ b/surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/service/VelocityMessagingSenderService.kt
@@ -32,18 +32,55 @@ class VelocityMessagingSenderService(): MessagingSenderService, Services.Fallbac
         channel: String,
         forwardingServers: ObjectSet<String>
     ) {
-        for (backend in forwardingServers) {
-            val server = plugin.proxy.getServer(backend).getOrNull() ?: continue
+        when(type) {
+            ChatMessageType.GLOBAL -> {
+                for (backend in forwardingServers) {
+                    val server = plugin.proxy.getServer(backend).getOrNull() ?: continue
 
-            server.sendPluginMessage(messageChannel, ByteStreams.newDataOutput().apply {
-                writeUTF(player)
-                writeUTF(target)
-                writeUTF(GsonComponentSerializer.gson().serialize(message))
-                writeUTF(gson.toJson(type))
-                writeUTF(messageID.toString())
-                writeUTF(channel)
-                writeUTF(gson.toJson(forwardingServers))
-            }.toByteArray())
+                    server.sendPluginMessage(messageChannel, ByteStreams.newDataOutput().apply {
+                        writeUTF(player)
+                        writeUTF(target)
+                        writeUTF(GsonComponentSerializer.gson().serialize(message))
+                        writeUTF(gson.toJson(type))
+                        writeUTF(messageID.toString())
+                        writeUTF(channel)
+                        writeUTF(gson.toJson(forwardingServers))
+                    }.toByteArray())
+                }
+            }
+
+            ChatMessageType.PRIVATE_FROM -> {
+                val targetServer = plugin.proxy.getPlayer(player).getOrNull()?.currentServer?.getOrNull() ?: return
+
+                targetServer.sendPluginMessage(messageChannel, ByteStreams.newDataOutput().apply {
+                    writeUTF(player)
+                    writeUTF(target)
+                    writeUTF(GsonComponentSerializer.gson().serialize(message))
+                    writeUTF(gson.toJson(type))
+                    writeUTF(messageID.toString())
+                    writeUTF(channel)
+                    writeUTF(gson.toJson(forwardingServers))
+                }.toByteArray())
+            }
+
+            ChatMessageType.PRIVATE_TO -> {
+                val targetServer = plugin.proxy.getPlayer(player).getOrNull()?.currentServer?.getOrNull() ?: return
+
+                targetServer.sendPluginMessage(messageChannel, ByteStreams.newDataOutput().apply {
+                    writeUTF(player)
+                    writeUTF(target)
+                    writeUTF(GsonComponentSerializer.gson().serialize(message))
+                    writeUTF(gson.toJson(type))
+                    writeUTF(messageID.toString())
+                    writeUTF(channel)
+                    writeUTF(gson.toJson(forwardingServers))
+                }.toByteArray())
+            }
+            else -> {
+                /**
+                 * Do nothing, other types are not supported
+                 */
+            }
         }
     }
 }


### PR DESCRIPTION
This pull request introduces significant changes to the private messaging system across the Bukkit and Velocity implementations. The updates include replacing player-based arguments with string-based arguments for better flexibility, enhancing message handling for private messages, and refining the chat format to remove unnecessary prefixes. Additionally, new logic has been added to handle private messaging types in both the Bukkit and Velocity messaging services.

### Changes to Private Messaging Command:
* Replaced `PlayerArgument` with `StringArgument` for the "player" argument in `PrivateMessageCommand`, enabling the use of player names directly instead of requiring a `Player` object. (`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.kt`, [[1]](diffhunk://#diff-47c44fa79ee8c97a63901c7560f2c36162d7f610690f435fd1279e3c3cbd1828L7-R30) [[2]](diffhunk://#diff-47c44fa79ee8c97a63901c7560f2c36162d7f610690f435fd1279e3c3cbd1828L36-R80)
* Added logic to handle cases where the target player is offline, ensuring messages are sent via the messaging service instead of directly. (`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.kt`, [surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.ktL36-R80](diffhunk://#diff-47c44fa79ee8c97a63901c7560f2c36162d7f610690f435fd1279e3c3cbd1828L36-R80))

### Updates to Chat Format:
* Removed the use of the LuckPerms prefix in the chat format for private messages, simplifying the display to only show player names. (`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/model/BukkitChatFormat.kt`, [[1]](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL77-R77) [[2]](diffhunk://#diff-96aaf91d6762d46a31c9b80a247216a8bcfd1eb2dc2925132cf053675963c65fL92-R92)

### Enhancements to Messaging Services:
* Added support for handling private message types (`PRIVATE_FROM` and `PRIVATE_TO`) in the `BukkitMessagingReceiverService`, enabling proper logging and message delivery. (`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt`, [surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.ktR49-R75](diffhunk://#diff-6883392f27b0ed16cbf503fa994c99b293a71d799b9c645681a7825e6f08466eR49-R75))
* Implemented similar handling for private message types in the `VelocityMessagingSenderService`, ensuring messages are forwarded correctly between servers. (`surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/service/VelocityMessagingSenderService.kt`, [[1]](diffhunk://#diff-9827ec83ff557553bb54d3db7cc9fa89bd2e95c0947d67e599c9f8bd2ab5fec7R35-R36) [[2]](diffhunk://#diff-9827ec83ff557553bb54d3db7cc9fa89bd2e95c0947d67e599c9f8bd2ab5fec7R51-R85)