### PR TITLE
Feat/add signed message deletion

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 paper-api = "1.21.4-R0.1-SNAPSHOT"
 velocity-api = "3.4.0-SNAPSHOT"
-surf-database = "1.0.4-SNAPSHOT"
+surf-database = "1.0.5-SNAPSHOT"
 luckperms-api = "5.4"
 fastutil = "8.2.1"
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/api/BukkitSurfChatApi.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/api/BukkitSurfChatApi.kt
@@ -31,7 +31,5 @@ class BukkitSurfChatApi(): SurfChatApi, Fallback {
         player.sendText {
             append(message)
         }
-
-        historyService.logCaching(player.uniqueId, LoggedMessage("Unknown", player.name, message), messageID)
     }
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatDeleteCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatDeleteCommand.kt
@@ -4,7 +4,6 @@ import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.kotlindsl.playerExecutor
 import dev.jorel.commandapi.kotlindsl.stringArgument
 import dev.slne.surf.chat.api.surfChatApi
-import dev.slne.surf.chat.bukkit.util.serverPlayers
 import dev.slne.surf.chat.core.service.historyService
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import java.util.*
@@ -16,10 +15,12 @@ class SurfChatDeleteCommand(commandName: String) : CommandAPICommand(commandName
         playerExecutor { player, args ->
             val messageID = args.getUnchecked<String>("messageID") ?: return@playerExecutor
 
-            serverPlayers.forEach {
-                historyService.deleteMessage(it.uniqueId, player.name, UUID.fromString(messageID))
-                historyService.resendMessages(it.uniqueId)
-            }
+            historyService.deleteMessage(player.name, UUID.fromString(messageID))
+
+//            serverPlayers.forEach {
+//                historyService.deleteMessage(it.uniqueId, player.name, UUID.fromString(messageID))
+//                historyService.resendMessages(it.uniqueId)
+//            }
 
             surfChatApi.sendText(player, buildText {
                 primary("Die Nachricht wurde gelöscht.")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatDeleteCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatDeleteCommand.kt
@@ -17,11 +17,6 @@ class SurfChatDeleteCommand(commandName: String) : CommandAPICommand(commandName
 
             historyService.deleteMessage(player.name, UUID.fromString(messageID))
 
-//            serverPlayers.forEach {
-//                historyService.deleteMessage(it.uniqueId, player.name, UUID.fromString(messageID))
-//                historyService.resendMessages(it.uniqueId)
-//            }
-
             surfChatApi.sendText(player, buildText {
                 primary("Die Nachricht wurde gelöscht.")
             })

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
@@ -3,11 +3,9 @@ package dev.slne.surf.chat.bukkit.listener
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.chat.api.surfChatApi
 import dev.slne.surf.chat.api.type.ChatMessageType
-import dev.slne.surf.chat.api.util.history.LoggedMessage
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.bukkit.service.BukkitMessagingSenderService
 import dev.slne.surf.chat.bukkit.util.sendText
-import dev.slne.surf.chat.bukkit.util.serverPlayers
 import dev.slne.surf.chat.bukkit.util.toPlainText
 import dev.slne.surf.chat.core.service.channelService
 import dev.slne.surf.chat.core.service.historyService
@@ -47,10 +45,8 @@ class BukkitChatListener(): Listener {
                 .build()
         )
 
+        historyService.logCaching(event.signedMessage(), messageID)
 
-        serverPlayers.forEach {
-            historyService.logCaching(it.uniqueId, LoggedMessage(player.name, "Unknown", formattedMessage), messageID)
-        }
 
         val channel = channelService.getChannel(player)
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/BukkitChatListener.kt
@@ -18,6 +18,7 @@ import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import java.util.UUID
 import java.util.regex.Pattern
+import kotlin.math.sign
 
 class BukkitChatListener(): Listener {
     private val pattern = Regex("^@(all|a|here|everyone)\\b\\s*", RegexOption.IGNORE_CASE)
@@ -45,8 +46,13 @@ class BukkitChatListener(): Listener {
                 .build()
         )
 
-        historyService.logCaching(event.signedMessage(), messageID)
+        val signature = event.signedMessage().signature()
 
+        if(signature != null) {
+            historyService.logCaching(signature, messageID)
+        } else {
+            plugin.logger.warning("Message signature is null for player ${player.name} with message: $message")
+        }
 
         val channel = channelService.getChannel(player)
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.kt
@@ -57,6 +57,7 @@ class BukkitHistoryService(): HistoryService, Fallback {
         val signedMessage = messageCache[messageID] ?: return
 
         Bukkit.getServer().deleteMessage(signedMessage)
+        messageCache.remove(messageID)
 
         plugin.launch {
             databaseService.markMessageDeleted(name, messageID)
@@ -64,25 +65,7 @@ class BukkitHistoryService(): HistoryService, Fallback {
     }
 
 
-    override fun resendMessages(player: UUID) {
-        val chatHistory = historyCache.getIfPresent(player) ?: return
-        val receiver = player(player) ?: return
-
-        repeat(100) {
-            receiver.sendMessage(Component.empty())
-        }
-
-        chatHistory.object2ObjectEntrySet()
-            .sortedBy { it.key.sendTime }
-            .take(25)
-            .forEach { (_, value) ->
-                receiver.sendMessage { value.message }
-            }
-    }
-
     override fun clearChat() {
-        historyCache.invalidateAll()
-
         forEachPlayer { player ->
             repeat(100) {
                 player.sendMessage(Component.empty())

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.kt
@@ -17,6 +17,7 @@ import dev.slne.surf.surfapi.bukkit.api.util.forEachPlayer
 import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
 import dev.slne.surf.surfapi.core.api.util.object2ObjectMapOf
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap
+import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap
 import it.unimi.dsi.fastutil.objects.ObjectList
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
@@ -31,7 +32,7 @@ class BukkitHistoryService(): HistoryService, Fallback {
         .maximumSize(1000)
         .build<UUID, Object2ObjectMap<HistoryPair, LoggedMessage>>()
 
-    private val messageCache = object2ObjectMapOf<UUID, SignedMessage>()
+    private val messageCache: Object2ObjectMap<UUID, SignedMessage.Signature> = Object2ObjectOpenHashMap()
 
     override suspend fun write(user: UUID, type: ChatMessageType, message: Component, messageID: UUID) {
         databaseService.insertHistoryEntry(user, BukkitHistoryEntry(
@@ -48,7 +49,7 @@ class BukkitHistoryService(): HistoryService, Fallback {
         return databaseService.loadHistory(user.uuid)
     }
 
-    override fun logCaching(message: SignedMessage, messageID: UUID) {
+    override fun logCaching(message: SignedMessage.Signature, messageID: UUID) {
         this.messageCache[messageID] = message
     }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt
@@ -49,21 +49,18 @@ class BukkitMessagingReceiverService : MessagingReceiverService, PluginMessageLi
         when(type) {
             ChatMessageType.GLOBAL -> {
                 serverPlayers.forEach {
-                    historyService.logCaching(it.uniqueId, LoggedMessage(player, target, message), messageID)
                     it.sendMessage(message)
                 }
             }
             ChatMessageType.PRIVATE_FROM -> {
                 val targetPlayer = Bukkit.getPlayer(target) ?: return
 
-                historyService.logCaching(targetPlayer.uniqueId, LoggedMessage(player, target, message), messageID)
                 targetPlayer.sendMessage(message)
             }
 
             ChatMessageType.PRIVATE_TO -> {
                 val targetPlayer = Bukkit.getPlayer(player) ?: return
 
-                historyService.logCaching(targetPlayer.uniqueId, LoggedMessage(player, target, message), messageID)
                 targetPlayer.sendMessage(message)
             }
 

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/HistoryService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/HistoryService.kt
@@ -17,7 +17,6 @@ interface HistoryService {
 
     fun logCaching(message: SignedMessage.Signature, messageID: UUID)
     fun deleteMessage(name: String, messageID: UUID)
-    fun resendMessages(player: UUID)
     fun clearChat()
 
     companion object {

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/HistoryService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/HistoryService.kt
@@ -7,6 +7,7 @@ import dev.slne.surf.chat.api.util.history.LoggedMessage
 import dev.slne.surf.surfapi.core.api.util.requiredService
 
 import it.unimi.dsi.fastutil.objects.ObjectList
+import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
 import java.util.UUID
 
@@ -14,8 +15,8 @@ interface HistoryService {
     suspend fun write(user: UUID, type: ChatMessageType, message: Component, messageID: UUID)
     suspend fun getHistory(user: ChatUserModel): ObjectList<HistoryEntryModel>
 
-    fun logCaching(player: UUID, message: LoggedMessage, messageID: UUID)
-    fun deleteMessage(player: UUID, name: String, messageID: UUID)
+    fun logCaching(message: SignedMessage, messageID: UUID)
+    fun deleteMessage(name: String, messageID: UUID)
     fun resendMessages(player: UUID)
     fun clearChat()
 

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/HistoryService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/HistoryService.kt
@@ -15,7 +15,7 @@ interface HistoryService {
     suspend fun write(user: UUID, type: ChatMessageType, message: Component, messageID: UUID)
     suspend fun getHistory(user: ChatUserModel): ObjectList<HistoryEntryModel>
 
-    fun logCaching(message: SignedMessage, messageID: UUID)
+    fun logCaching(message: SignedMessage.Signature, messageID: UUID)
     fun deleteMessage(name: String, messageID: UUID)
     fun resendMessages(player: UUID)
     fun clearChat()


### PR DESCRIPTION
This pull request refactors the chat history management system by replacing the use of `LoggedMessage` with `SignedMessage.Signature` for message tracking and caching. It also simplifies the codebase by removing unused methods and dependencies. Below is a summary of the most important changes:

### Chat History Refactoring:
* Replaced the `logCaching` method's `LoggedMessage` parameter with `SignedMessage.Signature` in `HistoryService` and its implementations. This change alters how messages are cached and tracked. (`[[1]](diffhunk://#diff-90980bf1b11dbef1e526fbf5b8720d4e11aaa9b8c1e3ba07eb2d709d5d2b043dL46-L85)`, `[[2]](diffhunk://#diff-5c67155ba93fc1556c169cb035a0bc2176b2f345a3f816698c3226dabe6cd3e6R10-R19)`)
* Updated the `deleteMessage` method to use `SignedMessage.Signature` for message deletion, removing the dependency on `serverPlayers`. (`[[1]](diffhunk://#diff-90980bf1b11dbef1e526fbf5b8720d4e11aaa9b8c1e3ba07eb2d709d5d2b043dL46-L85)`, `[[2]](diffhunk://#diff-c7c67b4a6fe78cf86d8f760eb99f008430733a0a642ef69d74483344f762457bL19-R18)`)
* Removed the `resendMessages` method from `HistoryService` and its implementations, as it is no longer needed. (`[[1]](diffhunk://#diff-90980bf1b11dbef1e526fbf5b8720d4e11aaa9b8c1e3ba07eb2d709d5d2b043dL46-L85)`, `[[2]](diffhunk://#diff-5c67155ba93fc1556c169cb035a0bc2176b2f345a3f816698c3226dabe6cd3e6R10-R19)`)

### Dependency Cleanup:
* Removed unused imports, including `LoggedMessage` and `serverPlayers`, across multiple files to clean up the codebase. (`[[1]](diffhunk://#diff-c7c67b4a6fe78cf86d8f760eb99f008430733a0a642ef69d74483344f762457bL7)`, `[[2]](diffhunk://#diff-0e0dc6039f6c5afbea5c70a331f599a39868a770264596c3f2f63641d341cc37L6-L10)`, `[[3]](diffhunk://#diff-5c67155ba93fc1556c169cb035a0bc2176b2f345a3f816698c3226dabe6cd3e6R10-R19)`)
* Updated the `surf-database` dependency version from `1.0.4-SNAPSHOT` to `1.0.5-SNAPSHOT` in `gradle/libs.versions.toml`. (`[gradle/libs.versions.tomlL4-R4](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL4-R4)`)

### Code Simplification:
* Simplified the `BukkitMessagingReceiverService` by removing redundant calls to `logCaching` for private and global messages. (`[surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.ktL52-L66](diffhunk://#diff-6883392f27b0ed16cbf503fa994c99b293a71d799b9c645681a7825e6f08466eL52-L66)`)
* Added a new `messageCache` in `BukkitHistoryService` to store `SignedMessage.Signature` objects for efficient message handling. (`[surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitHistoryService.ktR35-R36](diffhunk://#diff-90980bf1b11dbef1e526fbf5b8720d4e11aaa9b8c1e3ba07eb2d709d5d2b043dR35-R36)`)