### PR TITLE
Fix/26 fix global pms

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.kt
@@ -4,30 +4,27 @@ import com.github.shynixn.mccoroutine.folia.launch
 
 import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.arguments.ArgumentSuggestions
-import dev.jorel.commandapi.arguments.StringArgument
+import dev.jorel.commandapi.arguments.PlayerArgument
 import dev.jorel.commandapi.kotlindsl.greedyStringArgument
 import dev.jorel.commandapi.kotlindsl.playerExecutor
 
 import dev.slne.surf.chat.api.surfChatApi
 import dev.slne.surf.chat.api.type.ChatMessageType
 import dev.slne.surf.chat.bukkit.plugin
-import dev.slne.surf.chat.bukkit.service.BukkitMessagingSenderService
 import dev.slne.surf.chat.bukkit.util.sendRawText
 import dev.slne.surf.chat.bukkit.util.sendText
 import dev.slne.surf.chat.bukkit.util.serverPlayers
 import dev.slne.surf.chat.core.service.databaseService
-import dev.slne.surf.chat.core.service.messaging.messagingSenderService
 import dev.slne.surf.chat.core.service.replyService
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 
 import net.kyori.adventure.text.Component
-import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 import java.util.*
 
 class PrivateMessageCommand(commandName: String) : CommandAPICommand(commandName) {
     init {
-        withArguments(StringArgument("player").replaceSuggestions(ArgumentSuggestions.stringCollection {
+        withArguments(PlayerArgument("player").replaceSuggestions(ArgumentSuggestions.stringCollection {
             serverPlayers.map { it.name }
         }))
         greedyStringArgument("message")
@@ -36,52 +33,29 @@ class PrivateMessageCommand(commandName: String) : CommandAPICommand(commandName
         withPermission("surf.chat.command.private-message")
         playerExecutor { player, args ->
             plugin.launch {
-                val target = args.getUnchecked<String>("player") ?: return@launch
+                val target = args.getUnchecked<Player>("player") ?: return@launch
                 val message = args.getUnchecked<String>("message") ?: return@launch
                 val messageComponent = Component.text(message)
 
-                val targetPlayer: Player? = Bukkit.getPlayer(target)
                 val user = databaseService.getUser(player.uniqueId)
+                val targetUser = databaseService.getUser(target.uniqueId)
 
-                if(player.name == target) {
+                if(targetUser.uuid == user.uuid) {
                     user.sendText(buildText {
                         error("Du kannst dir nicht selbst eine Nachricht senden.")
                     })
                     return@launch
                 }
 
-                if(targetPlayer == null) {
-                    plugin.messageValidator.parse(messageComponent, ChatMessageType.PRIVATE_TO, player) {
-                        user.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, player, ChatMessageType.PRIVATE_TO, "", UUID.randomUUID(), true))
+                plugin.messageValidator.parse(messageComponent, ChatMessageType.PRIVATE_TO, player) {
+                    targetUser.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, target, ChatMessageType.PRIVATE_FROM, "", UUID.randomUUID(), true))
+                    user.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, target, ChatMessageType.PRIVATE_TO, "", UUID.randomUUID(), true))
 
-                        plugin.launch {
-                            surfChatApi.logMessage(player.uniqueId, ChatMessageType.PRIVATE_GENERAL, messageComponent, UUID.randomUUID())
-                        }
+                    replyService.updateLast(player.uniqueId, target.uniqueId)
+                    replyService.updateLast(target.uniqueId, player.uniqueId)
 
-                        messagingSenderService.sendData (
-                            player.name,
-                            target,
-                            messageComponent,
-                            ChatMessageType.PRIVATE_FROM,
-                            UUID.randomUUID(),
-                            "N/A",
-                            BukkitMessagingSenderService.getForwardingServers()
-                        )
-                    }
-                } else {
-                    val user = databaseService.getUser(player.uniqueId)
-                    val targetUser = databaseService.getUser(targetPlayer.uniqueId)
-
-                    plugin.messageValidator.parse(messageComponent, ChatMessageType.PRIVATE_TO, player) {
-                        targetUser.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, targetPlayer, ChatMessageType.PRIVATE_FROM, "", UUID.randomUUID(), true))
-                        user.sendRawText(plugin.chatFormat.formatMessage(messageComponent, player, player, ChatMessageType.PRIVATE_TO, "", UUID.randomUUID(), true))
-
-                        replyService.updateLast(player.uniqueId, targetUser.uuid)
-                        replyService.updateLast(targetUser.uuid, player.uniqueId)
-
-                        plugin.launch {
-                            surfChatApi.logMessage(player.uniqueId, ChatMessageType.PRIVATE_GENERAL, messageComponent, UUID.randomUUID())
-                        }
+                    plugin.launch {
+                        surfChatApi.logMessage(player.uniqueId, ChatMessageType.PRIVATE_GENERAL, messageComponent, UUID.randomUUID())
                     }
                 }
             }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt
@@ -46,29 +46,10 @@ class BukkitMessagingReceiverService : MessagingReceiverService, PluginMessageLi
         channel: String,
         forwardingServers: ObjectSet<String>
     ) {
-        when(type) {
-            ChatMessageType.GLOBAL -> {
-                serverPlayers.forEach {
-                    it.sendMessage(message)
-                }
-            }
-            ChatMessageType.PRIVATE_FROM -> {
-                val targetPlayer = Bukkit.getPlayer(target) ?: return
-
-                targetPlayer.sendMessage(message)
-            }
-
-            ChatMessageType.PRIVATE_TO -> {
-                val targetPlayer = Bukkit.getPlayer(player) ?: return
-
-                targetPlayer.sendMessage(message)
-            }
-
-            else -> {
-                /**
-                 * Do nothing, other types are not supported
-                 */
-            }
+        serverPlayers.forEach {
+            historyService.logCaching(it.uniqueId, LoggedMessage(player, "Unknown", message), messageID)
         }
+
+        Bukkit.broadcast(message)
     }
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt
@@ -46,10 +46,6 @@ class BukkitMessagingReceiverService : MessagingReceiverService, PluginMessageLi
         channel: String,
         forwardingServers: ObjectSet<String>
     ) {
-        serverPlayers.forEach {
-            historyService.logCaching(it.uniqueId, LoggedMessage(player, "Unknown", message), messageID)
-        }
-
         Bukkit.broadcast(message)
     }
 }

--- a/surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/service/VelocityMessagingSenderService.kt
+++ b/surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/service/VelocityMessagingSenderService.kt
@@ -32,55 +32,18 @@ class VelocityMessagingSenderService(): MessagingSenderService, Services.Fallbac
         channel: String,
         forwardingServers: ObjectSet<String>
     ) {
-        when(type) {
-            ChatMessageType.GLOBAL -> {
-                for (backend in forwardingServers) {
-                    val server = plugin.proxy.getServer(backend).getOrNull() ?: continue
+        for (backend in forwardingServers) {
+            val server = plugin.proxy.getServer(backend).getOrNull() ?: continue
 
-                    server.sendPluginMessage(messageChannel, ByteStreams.newDataOutput().apply {
-                        writeUTF(player)
-                        writeUTF(target)
-                        writeUTF(GsonComponentSerializer.gson().serialize(message))
-                        writeUTF(gson.toJson(type))
-                        writeUTF(messageID.toString())
-                        writeUTF(channel)
-                        writeUTF(gson.toJson(forwardingServers))
-                    }.toByteArray())
-                }
-            }
-
-            ChatMessageType.PRIVATE_FROM -> {
-                val targetServer = plugin.proxy.getPlayer(player).getOrNull()?.currentServer?.getOrNull() ?: return
-
-                targetServer.sendPluginMessage(messageChannel, ByteStreams.newDataOutput().apply {
-                    writeUTF(player)
-                    writeUTF(target)
-                    writeUTF(GsonComponentSerializer.gson().serialize(message))
-                    writeUTF(gson.toJson(type))
-                    writeUTF(messageID.toString())
-                    writeUTF(channel)
-                    writeUTF(gson.toJson(forwardingServers))
-                }.toByteArray())
-            }
-
-            ChatMessageType.PRIVATE_TO -> {
-                val targetServer = plugin.proxy.getPlayer(player).getOrNull()?.currentServer?.getOrNull() ?: return
-
-                targetServer.sendPluginMessage(messageChannel, ByteStreams.newDataOutput().apply {
-                    writeUTF(player)
-                    writeUTF(target)
-                    writeUTF(GsonComponentSerializer.gson().serialize(message))
-                    writeUTF(gson.toJson(type))
-                    writeUTF(messageID.toString())
-                    writeUTF(channel)
-                    writeUTF(gson.toJson(forwardingServers))
-                }.toByteArray())
-            }
-            else -> {
-                /**
-                 * Do nothing, other types are not supported
-                 */
-            }
+            server.sendPluginMessage(messageChannel, ByteStreams.newDataOutput().apply {
+                writeUTF(player)
+                writeUTF(target)
+                writeUTF(GsonComponentSerializer.gson().serialize(message))
+                writeUTF(gson.toJson(type))
+                writeUTF(messageID.toString())
+                writeUTF(channel)
+                writeUTF(gson.toJson(forwardingServers))
+            }.toByteArray())
         }
     }
 }


### PR DESCRIPTION
This pull request refactors the private messaging system in the `surf-chat` project to simplify the codebase, improve type safety, and remove redundant logic. The changes primarily impact the `PrivateMessageCommand` class, messaging services, and the handling of private message types.

### Refactoring of `PrivateMessageCommand`:

* Replaced `StringArgument` with `PlayerArgument` for the "player" argument to ensure type safety when resolving player targets. (`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.kt`) [[1]](diffhunk://#diff-47c44fa79ee8c97a63901c7560f2c36162d7f610690f435fd1279e3c3cbd1828L7-R27) [[2]](diffhunk://#diff-47c44fa79ee8c97a63901c7560f2c36162d7f610690f435fd1279e3c3cbd1828L39-R55)
* Simplified logic by removing the need to manually fetch the target player using `Bukkit.getPlayer` and instead directly accessing the `Player` object from the argument. (`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.kt`)
* Removed redundant fallback logic for handling cases where the target player was not found, as `PlayerArgument` inherently ensures valid player resolution. (`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/PrivateMessageCommand.kt`)

### Simplification of Messaging Services:

* Removed type-specific handling (`PRIVATE_FROM`, `PRIVATE_TO`) in `BukkitMessagingReceiverService` and replaced it with a single `Bukkit.broadcast` call, streamlining message dispatch. (`surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitMessagingReceiverService.kt`)
* Eliminated redundant private message handling logic in `VelocityMessagingSenderService` to reduce complexity and improve maintainability. (`surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/service/VelocityMessagingSenderService.kt`) [[1]](diffhunk://#diff-9827ec83ff557553bb54d3db7cc9fa89bd2e95c0947d67e599c9f8bd2ab5fec7L35-L36) [[2]](diffhunk://#diff-9827ec83ff557553bb54d3db7cc9fa89bd2e95c0947d67e599c9f8bd2ab5fec7L51-L85)