### PR TITLE
Feat/59 add denylist to prevent specific messages

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitCommandManager.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitCommandManager.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.chat.bukkit
 
 import dev.slne.surf.chat.bukkit.command.channel.channelAdminCommand
 import dev.slne.surf.chat.bukkit.command.channel.channelCommand
+import dev.slne.surf.chat.bukkit.command.denylist.denylistCommand
 import dev.slne.surf.chat.bukkit.command.settings.settingsCommand
 import dev.slne.surf.chat.bukkit.command.surfchat.surfChatCommand
 import dev.slne.surf.chat.bukkit.command.teamchatCommand
@@ -13,5 +14,6 @@ object BukkitCommandManager {
         teamchatCommand()
         channelCommand()
         channelAdminCommand()
+        denylistCommand()
     }
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
@@ -4,6 +4,7 @@ import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
 import dev.slne.surf.chat.bukkit.config.ChatMotdConfigProvider
 import dev.slne.surf.chat.bukkit.config.ConnectionMessageConfigProvider
 import dev.slne.surf.chat.core.service.databaseService
+import dev.slne.surf.chat.core.service.denylistService
 import org.bukkit.plugin.java.JavaPlugin
 import java.util.*
 
@@ -21,6 +22,10 @@ class BukkitMain : SuspendingJavaPlugin() {
         BukkitCommandManager.registerCommands()
         BukkitListenerManager.registerBukkitListeners()
         BukkitListenerManager.registerPacketListeners()
+    }
+
+    override suspend fun onEnableAsync() {
+        denylistService.fetch()
     }
 
     override fun onDisable() {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.chat.bukkit
 
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
+import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.chat.bukkit.config.ChatMotdConfigProvider
 import dev.slne.surf.chat.bukkit.config.ConnectionMessageConfigProvider
 import dev.slne.surf.chat.core.service.databaseService
@@ -22,10 +23,10 @@ class BukkitMain : SuspendingJavaPlugin() {
         BukkitCommandManager.registerCommands()
         BukkitListenerManager.registerBukkitListeners()
         BukkitListenerManager.registerPacketListeners()
-    }
 
-    override suspend fun onEnableAsync() {
-        denylistService.fetch()
+        launch {
+            denylistService.fetch()
+        }
     }
 
     override fun onDisable() {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/DenylistWordArgument.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/DenylistWordArgument.kt
@@ -1,0 +1,35 @@
+package dev.slne.surf.chat.bukkit.command.argument
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.StringArgument
+import dev.slne.surf.chat.core.service.denylistService
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+
+class DenylistWordArgument(nodeName: String) :
+    CustomArgument<String, String>(StringArgument(nodeName), { info ->
+        denylistService.getLocalEntry(info.input)
+            ?: throw CustomArgumentException.fromAdventureComponent {
+                buildText {
+                    appendPrefix()
+                    error("Das Wort ist nicht auf der internen Denylist.")
+                }
+            }
+
+        info.input
+    }) {
+    init {
+        replaceSuggestions(ArgumentSuggestions.stringCollection {
+            denylistService.getLocalEntries().map { it.word }
+        })
+    }
+}
+
+inline fun CommandAPICommand.denylistWordArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandAPICommand =
+    withArguments(DenylistWordArgument(nodeName).setOptional(optional).apply(block))

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistAddCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistAddCommand.kt
@@ -1,0 +1,63 @@
+package dev.slne.surf.chat.bukkit.command.denylist
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.*
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.bukkit.util.realName
+import dev.slne.surf.chat.core.service.denylistService
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+
+fun CommandAPICommand.denylistAddCommand() = subcommand("add") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_ADD)
+    stringArgument("word")
+    greedyStringArgument("reason")
+    anyExecutor { executor, args ->
+        val word: String by args
+        val reason: String by args
+        val addedAt = System.currentTimeMillis()
+        val name = executor.realName()
+
+
+        if (denylistService.hasLocalEntry(word)) {
+            executor.sendText {
+                appendPrefix()
+                error("Der Eintrag ")
+                variableValue(word)
+                error(" ist bereits in der internen Denylist vorhanden.")
+            }
+            return@anyExecutor
+        }
+
+        denylistService.addLocalEntry(word, reason, name, addedAt)
+
+        executor.sendText {
+            appendPrefix()
+            success("Der Eintrag ")
+            variableValue(word)
+            success(" wurde erfolgreich zur internen Denylist hinzugefügt.")
+        }
+
+        plugin.launch {
+            if (denylistService.hasEntry(word)) {
+                executor.sendText {
+                    appendPrefix()
+                    error("Der Eintrag ")
+                    variableValue(word)
+                    error(" ist bereits in der externen Denylist vorhanden.")
+                }
+                return@launch
+            }
+
+            denylistService.addEntry(word, reason, name, addedAt)
+
+            executor.sendText {
+                appendPrefix()
+                success("Der Eintrag ")
+                variableValue(word)
+                success(" wurde erfolgreich zur externen Denylist hinzugefügt.")
+            }
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistAddCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistAddCommand.kt
@@ -12,10 +12,10 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 fun CommandAPICommand.denylistAddCommand() = subcommand("add") {
     withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_ADD)
     stringArgument("word")
-    greedyStringArgument("reason")
+    greedyStringArgument("reason", optional = true)
     anyExecutor { executor, args ->
         val word: String by args
-        val reason: String by args
+        val reason: String? by args
         val addedAt = System.currentTimeMillis()
         val name = executor.realName()
 
@@ -30,7 +30,7 @@ fun CommandAPICommand.denylistAddCommand() = subcommand("add") {
             return@anyExecutor
         }
 
-        denylistService.addLocalEntry(word, reason, name, addedAt)
+        denylistService.addLocalEntry(word, reason ?: "Verbotenes Wort", name, addedAt)
 
         executor.sendText {
             appendPrefix()
@@ -50,7 +50,7 @@ fun CommandAPICommand.denylistAddCommand() = subcommand("add") {
                 return@launch
             }
 
-            denylistService.addEntry(word, reason, name, addedAt)
+            denylistService.addEntry(word, reason ?: "Verbotenes Wort", name, addedAt)
 
             executor.sendText {
                 appendPrefix()

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistCommand.kt
@@ -1,0 +1,12 @@
+package dev.slne.surf.chat.bukkit.command.denylist
+
+import dev.jorel.commandapi.kotlindsl.commandAPICommand
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+
+fun denylistCommand() = commandAPICommand("denylist") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST)
+    denylistAddCommand()
+    denylistRemoveCommand()
+    denylistFetchCommand()
+    denylistListCommand()
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistFetchCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistFetchCommand.kt
@@ -1,0 +1,38 @@
+package dev.slne.surf.chat.bukkit.command.denylist
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.bukkit.util.coloredComponent
+import dev.slne.surf.chat.core.service.denylistService
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import kotlin.system.measureTimeMillis
+
+fun CommandAPICommand.denylistFetchCommand() = subcommand("fetch") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_FETCH)
+    anyExecutor { executor, args ->
+        executor.sendText {
+            appendPrefix()
+            info("Die Denylist wird aktualisiert...")
+        }
+
+        plugin.launch {
+            val ms = measureTimeMillis {
+                denylistService.fetch()
+            }
+
+            executor.sendText {
+                appendPrefix()
+                success("Die Denylist wurde erfolgreich aktualisiert")
+                appendSpace()
+                spacer("(")
+                append(ms.coloredComponent(50))
+                spacer(")")
+                success("!")
+            }
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistListCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistListCommand.kt
@@ -1,0 +1,70 @@
+package dev.slne.surf.chat.bukkit.command.denylist
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.integerArgument
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.api.entry.DenylistEntry
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+import dev.slne.surf.chat.bukkit.util.unixTime
+import dev.slne.surf.chat.core.service.denylistService
+import dev.slne.surf.surfapi.core.api.font.toSmallCaps
+import dev.slne.surf.surfapi.core.api.messages.CommonComponents
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import dev.slne.surf.surfapi.core.api.messages.pagination.Pagination
+import net.kyori.adventure.text.format.TextDecoration
+
+fun CommandAPICommand.denylistListCommand() = subcommand("list") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_LIST)
+    integerArgument("page", min = 1, max = Int.MAX_VALUE, optional = true)
+    anyExecutor { executor, args ->
+        val page = args.getOrDefaultUnchecked("page", 1)
+        val denylistEntries = denylistService.getLocalEntries()
+
+        if (denylistEntries.isEmpty()) {
+            executor.sendText {
+                appendPrefix()
+                error("Es sind keine Einträge in der internen Denylist vorhanden.")
+            }
+            return@anyExecutor
+        }
+
+        val pagination = Pagination<DenylistEntry> {
+            title {
+                primary("Interne Denylist".toSmallCaps(), TextDecoration.BOLD)
+            }
+
+            rowRenderer { entry, _ ->
+                listOf(
+                    buildText {
+                        append(CommonComponents.EM_DASH)
+                        appendSpace()
+                        variableKey(entry.word)
+                        appendSpace()
+                        spacer("(${entry.addedBy})")
+                        hoverEvent(buildText {
+                            append(CommonComponents.EM_DASH)
+                            appendSpace()
+                            variableKey("Grund")
+                            spacer(":")
+                            appendSpace()
+                            variableValue(entry.reason)
+                            appendNewline()
+                            append(CommonComponents.EM_DASH)
+                            appendSpace()
+                            variableKey("Datum")
+                            spacer(":")
+                            appendSpace()
+                            variableValue(entry.addedAt.unixTime())
+                        })
+                    }
+                )
+            }
+        }
+
+        executor.sendText {
+            append(pagination.renderComponent(denylistEntries, page))
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistRemoveCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistRemoveCommand.kt
@@ -1,0 +1,60 @@
+package dev.slne.surf.chat.bukkit.command.denylist
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.stringArgument
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.core.service.denylistService
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+
+fun CommandAPICommand.denylistRemoveCommand() = subcommand("remove") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_REMOVE)
+    stringArgument("word")
+    anyExecutor { executor, args ->
+        val word: String by args
+
+        if (!denylistService.hasLocalEntry(word)) {
+            executor.sendText {
+                appendPrefix()
+                error("Der Eintrag ")
+                variableValue(word)
+                error(" ist nicht in der internen Denylist vorhanden.")
+            }
+            return@anyExecutor
+        }
+
+        denylistService.removeLocalEntry(word)
+
+        executor.sendText {
+            appendPrefix()
+            success("Der Eintrag ")
+            variableValue(word)
+            success(" wurde erfolgreich aus der internen Denylist gelöscht.")
+        }
+
+        plugin.launch {
+            if (!denylistService.hasEntry(word)) {
+                executor.sendText {
+                    appendPrefix()
+                    error("Der Eintrag ")
+                    variableValue(word)
+                    error(" ist nicht in der externen Denylist vorhanden.")
+                }
+                return@launch
+            }
+
+            denylistService.removeEntry(word)
+
+            executor.sendText {
+                appendPrefix()
+                success("Der Eintrag ")
+                variableValue(word)
+                success(" wurde erfolgreich aus der externen Denylist gelöscht.")
+            }
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistRemoveCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistRemoveCommand.kt
@@ -4,8 +4,8 @@ import com.github.shynixn.mccoroutine.folia.launch
 import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.kotlindsl.anyExecutor
 import dev.jorel.commandapi.kotlindsl.getValue
-import dev.jorel.commandapi.kotlindsl.stringArgument
 import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.bukkit.command.argument.denylistWordArgument
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.core.service.denylistService
@@ -13,7 +13,7 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 
 fun CommandAPICommand.denylistRemoveCommand() = subcommand("remove") {
     withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_REMOVE)
-    stringArgument("word")
+    denylistWordArgument("word")
     anyExecutor { executor, args ->
         val word: String by args
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatReloadCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatReloadCommand.kt
@@ -20,7 +20,7 @@ fun CommandAPICommand.surfChatReloadCommand() = subcommand("reload") {
         executor.sendText {
             appendPrefix()
             success("Successfully reloaded plugin in ")
-            append(ms.coloredComponent(50))
+            append(ms.coloredComponent(25))
             success("!")
         }
     }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/message/MessageValidatorImpl.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/message/MessageValidatorImpl.kt
@@ -4,12 +4,15 @@ import dev.slne.surf.chat.api.entity.User
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.util.plainText
 import dev.slne.surf.chat.core.message.MessageValidator
+import dev.slne.surf.chat.core.service.denylistService
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
 import dev.slne.surf.surfapi.core.api.util.mutableObjectListOf
 import dev.slne.surf.surfapi.core.api.util.mutableObjectSetOf
 import it.unimi.dsi.fastutil.objects.ObjectList
 import net.kyori.adventure.text.Component
+import org.bukkit.Bukkit
 import java.net.URI
 import java.util.*
 
@@ -44,6 +47,25 @@ class MessageValidatorImpl {
                 failureMessage = buildText {
                     error("Deine Nachricht darf nicht leer sein.")
                 }
+                return false
+            }
+
+            if (denylistService.getLocalEntries().any { message.contains(it.word, true) }) {
+                failureMessage = buildText {
+                    error("Bitte achte auf deine Wortwahl.")
+                }
+
+                Bukkit.getOnlinePlayers()
+                    .filter { it.hasPermission(SurfChatPermissionRegistry.TEAM_ACCESS) }.forEach {
+                        it.sendText {
+                            appendPrefix()
+                            info("Eine Nachricht von ")
+                            variableValue(user.name)
+                            info(" wurde blockiert: ")
+                            variableValue(message)
+                        }
+                    }
+
                 return false
             }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
@@ -17,6 +17,12 @@ object SurfChatPermissionRegistry : PermissionRegistry() {
     val COMMAND_SURFCHAT_LOOKUP = create("$PREFIX_COMMAND.surfchat.lookup")
     val COMMAND_SURFCHAT_LOOKUP_HELP = create("$PREFIX_COMMAND.surfchat.lookup.help")
 
+    val COMMAND_DENYLIST = create("$PREFIX_COMMAND.denylist")
+    val COMMAND_DENYLIST_ADD = create("$PREFIX_COMMAND.denylist.add")
+    val COMMAND_DENYLIST_REMOVE = create("$PREFIX_COMMAND.denylist.remove")
+    val COMMAND_DENYLIST_LIST = create("$PREFIX_COMMAND.denylist.list")
+    val COMMAND_DENYLIST_FETCH = create("$PREFIX_COMMAND.denylist.fetch")
+
     val COMMAND_CHANNEL = create("$PREFIX_COMMAND.channel")
     val COMMAND_CHANNEL_ACCEPT = create("$PREFIX_COMMAND.channel.accept")
     val COMMAND_CHANNEL_CREATE = create("$PREFIX_COMMAND.channel.create")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/player-extension.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/player-extension.kt
@@ -7,8 +7,11 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 import net.kyori.adventure.audience.Audience
 import org.bukkit.Bukkit
+import org.bukkit.command.BlockCommandSender
+import org.bukkit.command.CommandSender
 import org.bukkit.command.ConsoleCommandSender
 import org.bukkit.entity.Player
+import org.bukkit.entity.minecart.CommandMinecart
 
 fun User.player() = Bukkit.getPlayer(this.uuid)
 fun Audience.user() = when (this) {
@@ -23,6 +26,14 @@ fun Audience.isConsole() = this is ConsoleCommandSender
 fun Audience.name() = when (this) {
     is Player -> this.name
     is ConsoleCommandSender -> "Console"
+    else -> "Error"
+}
+
+fun CommandSender.realName() = when (this) {
+    is Player -> this.name
+    is ConsoleCommandSender -> "Console"
+    is BlockCommandSender -> "Block"
+    is CommandMinecart -> "CommandBlockMinecart"
     else -> "Error"
 }
 

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DenylistService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DenylistService.kt
@@ -1,0 +1,40 @@
+package dev.slne.surf.chat.core.service
+
+import dev.slne.surf.chat.api.entry.DenylistEntry
+import dev.slne.surf.surfapi.core.api.util.requiredService
+import it.unimi.dsi.fastutil.objects.ObjectList
+
+interface DenylistService : ServiceUsingDatabase {
+    suspend fun addEntry(
+        word: String,
+        reason: String,
+        addedBy: String,
+        addedAt: Long
+    )
+
+    fun addLocalEntry(
+        word: String,
+        reason: String,
+        addedBy: String,
+        addedAt: Long
+    )
+
+    fun removeLocalEntry(word: String)
+    fun hasLocalEntry(word: String): Boolean
+    fun getLocalEntry(word: String): DenylistEntry?
+    fun clearLocalEntries()
+    fun getLocalEntries(): ObjectList<DenylistEntry>
+
+    suspend fun removeEntry(word: String)
+    suspend fun hasEntry(word: String): Boolean
+    suspend fun getEntry(word: String): DenylistEntry?
+    suspend fun getEntries(): ObjectList<DenylistEntry>
+
+    suspend fun fetch()
+
+    companion object {
+        val INSTANCE = requiredService<DenylistService>()
+    }
+}
+
+val denylistService get() = DenylistService.INSTANCE

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/model/FallbackDenylistEntry.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/model/FallbackDenylistEntry.kt
@@ -1,0 +1,10 @@
+package dev.slne.surf.chat.fallback.model
+
+import dev.slne.surf.chat.api.entry.DenylistEntry
+
+class FallbackDenylistEntry(
+    override val word: String,
+    override val reason: String,
+    override val addedBy: String,
+    override val addedAt: Long
+) : DenylistEntry

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDatabaseService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDatabaseService.kt
@@ -1,10 +1,7 @@
 package dev.slne.surf.chat.fallback.service
 
 import com.google.auto.service.AutoService
-import dev.slne.surf.chat.core.service.DatabaseService
-import dev.slne.surf.chat.core.service.directMessageService
-import dev.slne.surf.chat.core.service.historyService
-import dev.slne.surf.chat.core.service.notificationService
+import dev.slne.surf.chat.core.service.*
 import dev.slne.surf.database.DatabaseManager
 import dev.slne.surf.database.database.DatabaseProvider
 import net.kyori.adventure.util.Services
@@ -22,6 +19,7 @@ class FallbackDatabaseService : DatabaseService, Services.Fallback {
         notificationService.createTable()
         directMessageService.createTable()
         historyService.createTable()
+        denylistService.createTable()
     }
 
     override fun closeConnection() {

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistService.kt
@@ -1,0 +1,133 @@
+package dev.slne.surf.chat.fallback.service
+
+import com.google.auto.service.AutoService
+import dev.slne.surf.chat.api.entry.DenylistEntry
+import dev.slne.surf.chat.core.service.DenylistService
+import dev.slne.surf.chat.fallback.model.FallbackDenylistEntry
+import dev.slne.surf.surfapi.core.api.util.mutableObjectListOf
+import dev.slne.surf.surfapi.core.api.util.toObjectList
+import it.unimi.dsi.fastutil.objects.ObjectList
+import kotlinx.coroutines.Dispatchers
+import net.kyori.adventure.util.Services
+import org.jetbrains.exposed.sql.*
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@AutoService(DenylistService::class)
+class FallbackDenylistService : DenylistService, Services.Fallback {
+    object DenylistEntries : Table("chat_denylist_entries") {
+        val index = integer("index").autoIncrement().uniqueIndex()
+        val word = text("word").uniqueIndex()
+        val reason = text("reason")
+        val addedBy = varchar("added_by", 16)
+        val addedAt = long("added_at")
+
+        override val primaryKey = PrimaryKey(index)
+    }
+
+    val entries = mutableObjectListOf<DenylistEntry>()
+
+    override fun createTable() {
+        transaction {
+            SchemaUtils.create(DenylistEntries)
+        }
+    }
+
+    override suspend fun addEntry(
+        word: String,
+        reason: String,
+        addedBy: String,
+        addedAt: Long
+    ) = newSuspendedTransaction(Dispatchers.IO) {
+        DenylistEntries.insert {
+            it[DenylistEntries.word] = word
+            it[DenylistEntries.reason] = reason
+            it[DenylistEntries.addedBy] = addedBy
+            it[DenylistEntries.addedAt] = addedAt
+        }
+
+        return@newSuspendedTransaction
+    }
+
+    override fun addLocalEntry(
+        word: String,
+        reason: String,
+        addedBy: String,
+        addedAt: Long
+    ) {
+        entries.add(
+            FallbackDenylistEntry(
+                word, reason, addedBy, addedAt
+            )
+        )
+    }
+
+    override fun removeLocalEntry(word: String) {
+        entries.removeIf { it.word == word }
+    }
+
+    override fun hasLocalEntry(word: String): Boolean {
+        return entries.any { it.word == word }
+    }
+
+    override fun getLocalEntry(word: String): DenylistEntry? {
+        return entries.find { it.word == word }
+    }
+
+    override fun clearLocalEntries() {
+        entries.clear()
+    }
+
+    override fun getLocalEntries(): ObjectList<DenylistEntry> {
+        return entries
+    }
+
+    override suspend fun removeEntry(word: String) = newSuspendedTransaction(Dispatchers.IO) {
+        DenylistEntries.deleteWhere { DenylistEntries.word eq word }
+        return@newSuspendedTransaction
+    }
+
+    override suspend fun hasEntry(word: String) = newSuspendedTransaction(Dispatchers.IO) {
+        val exists = DenylistEntries.selectAll().where(DenylistEntries.word eq word).count() > 0
+        return@newSuspendedTransaction exists
+    }
+
+    override suspend fun getEntry(word: String) = newSuspendedTransaction(Dispatchers.IO) {
+        DenylistEntries.selectAll().where(DenylistEntries.word eq word).map {
+            FallbackDenylistEntry(
+                it[DenylistEntries.word],
+                it[DenylistEntries.reason],
+                it[DenylistEntries.addedBy],
+                it[DenylistEntries.addedAt]
+            )
+        }.firstOrNull()
+    }
+
+    override suspend fun getEntries(): ObjectList<DenylistEntry> =
+        newSuspendedTransaction(Dispatchers.IO) {
+            DenylistEntries.selectAll().map {
+                FallbackDenylistEntry(
+                    it[DenylistEntries.word],
+                    it[DenylistEntries.reason],
+                    it[DenylistEntries.addedBy],
+                    it[DenylistEntries.addedAt]
+                )
+            }.toObjectList()
+        }
+
+    override suspend fun fetch() = newSuspendedTransaction(Dispatchers.IO) {
+        entries.clear()
+        entries.addAll(
+            DenylistEntries.selectAll().map {
+                FallbackDenylistEntry(
+                    it[DenylistEntries.word],
+                    it[DenylistEntries.reason],
+                    it[DenylistEntries.addedBy],
+                    it[DenylistEntries.addedAt]
+                )
+            }
+        )
+        return@newSuspendedTransaction
+    }
+}


### PR DESCRIPTION
This pull request introduces a new denylist feature to the `surf-chat-bukkit` module, enabling management of restricted words. Key changes include the addition of commands for managing the denylist, integration of the denylist into message validation, and the implementation of the `DenylistService`.

### Denylist Feature Implementation:

* **Command Additions:**
  - Added a new `denylistCommand` with subcommands for adding, removing, fetching, and listing denylist entries (`DenylistCommand.kt`, `DenylistAddCommand.kt`, `DenylistRemoveCommand.kt`, `DenylistFetchCommand.kt`, `DenylistListCommand.kt`). [[1]](diffhunk://#diff-9558702014fa531442282b637133360b940fb37bf975e57847dcf7631b5b6068R5) [[2]](diffhunk://#diff-9558702014fa531442282b637133360b940fb37bf975e57847dcf7631b5b6068R17) [[3]](diffhunk://#diff-33102249a9253ed296054bb5aa5955c7cc1449214f357317ba04e1213ef32b3fR1-R12) [[4]](diffhunk://#diff-974aa34372801a75a3ff14cac5003101547cb19aff5bb2a2f9e481d79c3de1d4R1-R63) [[5]](diffhunk://#diff-6f68d3fddd34375b1c4da576b161f7237b4180165e44c98f4d328f4f7974a529R1-R60) [[6]](diffhunk://#diff-f6ff824d94ec7087079203d42dcc0c54cd8a2449414447a39e08ce7da3ed0f13R1-R38) [[7]](diffhunk://#diff-e46255b83a8338f2f6dd96149f3cd44c469694b3584ba59bc0a7c4b148160e82R1-R70)

* **Service Integration:**
  - Introduced `DenylistService` interface and its fallback implementation for managing denylist entries (`DenylistService.kt`, `FallbackDenylistEntry.kt`, `FallbackDatabaseService.kt`). [[1]](diffhunk://#diff-40557dd31698e85ff42610b2ab33f68c1317770f9af1f500b9fefbeb5519c5e2R1-R40) [[2]](diffhunk://#diff-672e8ba4e939127e8baa2099581edc3c813cd926299c599b3b13d824d6380749R1-R10) [[3]](diffhunk://#diff-4e30c0f25acaa25f3958fd7243e78844d6e6270ff5915ab661b9d18725c191caL4-R4) [[4]](diffhunk://#diff-4e30c0f25acaa25f3958fd7243e78844d6e6270ff5915ab661b9d18725c191caR22)

* **Message Validation:**
  - Updated `MessageValidatorImpl` to block messages containing words from the denylist and notify team members (`MessageValidatorImpl.kt`). [[1]](diffhunk://#diff-728e3fd4808e51e620851b2f4e1964898acb73e51cb0afd00eaf5066306674f7R7-R15) [[2]](diffhunk://#diff-728e3fd4808e51e620851b2f4e1964898acb73e51cb0afd00eaf5066306674f7R53-R71)

### Code Enhancements:

* **New Utility Methods:**
  - Added `realName()` method for `CommandSender` to retrieve the sender's name (`player-extension.kt`). [[1]](diffhunk://#diff-d6a306e7d793ef3b5ab75320e9fbda4546ad739c60d52c9af39618138c7562c6R10-R14) [[2]](diffhunk://#diff-d6a306e7d793ef3b5ab75320e9fbda4546ad739c60d52c9af39618138c7562c6R32-R39)

* **Minor Adjustments:**
  - Adjusted the color intensity of reload timing in `SurfChatReloadCommand` (`SurfChatReloadCommand.kt`).