### PR TITLE
fix: ignore case when searching for denylisted word

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitDenylistService.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/service/BukkitDenylistService.kt
@@ -17,7 +17,7 @@ class BukkitDenylistService() : DenylistService, Fallback {
     private var denylist: ObjectSet<String> = mutableObjectSetOf()
 
     override fun isDenylisted(word: String): Boolean {
-        return denylist.contains(word)
+        return denylist.any { it.equals(word, ignoreCase = true) })
     }
 
     override fun hasDenyListed(message: Component): Boolean {


### PR DESCRIPTION
This pull request updates the `BukkitDenylistService` to improve how denylisted words are checked. The main change is making the denylist check case-insensitive, so words will be matched regardless of their letter casing.

**Denylist matching improvement:**

* Updated the `isDenylisted` method in `BukkitDenylistService` to perform a case-insensitive comparison when checking if a word is in the denylist.