### PR TITLE
Feat/add server api stuff

### DIFF
--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/server/ChatGroup.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/server/ChatGroup.kt
@@ -1,0 +1,8 @@
+package dev.slne.surf.chat.api.server
+
+import it.unimi.dsi.fastutil.objects.ObjectSet
+
+interface ChatGroup {
+  val name: String
+  val members: ObjectSet<ChatServer>
+}

--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/server/ChatServer.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/server/ChatServer.kt
@@ -1,0 +1,6 @@
+package dev.slne.surf.chat.api.server
+
+interface ChatServer {
+  val name: String
+  val internalName: String
+}


### PR DESCRIPTION
This pull request introduces two new interfaces to the codebase, laying the groundwork for representing chat servers and groups of servers. These interfaces define the core properties necessary for managing chat infrastructure.

Core API additions:

* Added the `ChatServer` interface with `name` and `internalName` properties to represent individual chat servers.
* Added the `ChatGroup` interface with `name` and a set of `ChatServer` members, enabling grouping of chat servers.