### PR TITLE
ci: add publish yml and vcs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,102 @@
+name: Publish to Maven & Create GitHub Release
+
+on:
+  push:
+    branches:
+      - 'version/*'
+  workflow_dispatch:
+
+env:
+  SLNE_SNAPSHOTS_REPO_USERNAME: ${{ secrets.SLNE_SNAPSHOTS_REPO_USERNAME }}
+  SLNE_SNAPSHOTS_REPO_PASSWORD: ${{ secrets.SLNE_SNAPSHOTS_REPO_PASSWORD }}
+  SLNE_RELEASES_REPO_USERNAME: ${{ secrets.SLNE_RELEASES_REPO_USERNAME }}
+  SLNE_RELEASES_REPO_PASSWORD: ${{ secrets.SLNE_RELEASES_REPO_PASSWORD }}
+  MODULE_REGEX: "surf-chat-api.*\\.jar$|surf-chat-bukkit.*\\.jar$|surf-chat-velocity.*\\.jar$"
+  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: gradle-${{ runner.os }}-
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'graalvm'
+          java-version: '24'
+
+      - name: Build all modules with Gradle
+        run: ./gradlew build shadowJar --parallel --no-scan
+
+      - name: Publish all modules to Maven
+        run: ./gradlew publish --parallel --no-scan
+
+      - name: Extract Project Version and Snapshot Flag from Gradle
+        id: get_version
+        run: |
+          VERSION=$(./gradlew properties --no-daemon \
+            | grep '^version:' \
+            | awk '{print $2}')
+          SNAPSHOT_FLAG=$(./gradlew properties --no-daemon \
+            | grep '^snapshot:' \
+            | awk '{print $2}')
+          if [ "$SNAPSHOT_FLAG" = "true" ]; then
+            VERSION="${VERSION}-SNAPSHOT"
+          fi
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "SNAPSHOT_FLAG=$SNAPSHOT_FLAG" >> $GITHUB_ENV
+
+      - name: Determine release flags
+        run: |
+          CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
+          # prerelease only for snapshots
+          if [ "${SNAPSHOT_FLAG}" = "true" ]; then
+            echo "PRERELEASE=true" >> $GITHUB_ENV
+          else
+            echo "PRERELEASE=false" >> $GITHUB_ENV
+          fi
+          # make_latest false for snapshots or non-default branches
+          if [ "${SNAPSHOT_FLAG}" = "true" ] || [ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
+            echo "MAKE_LATEST=false" >> $GITHUB_ENV
+          else
+            echo "MAKE_LATEST=true" >> $GITHUB_ENV
+          fi
+
+      - name: Find and filter JAR files
+        id: find_jars
+        run: |
+          echo "JAR_FILES<<EOF" >> $GITHUB_ENV
+          find . -path "**/build/libs/*.jar" \
+            | grep -E "${{ env.MODULE_REGEX }}" \
+            >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: v${{ env.VERSION }}
+          name: Release ${{ env.VERSION }}
+          draft: false
+          prerelease: ${{ env.PRERELEASE }}
+          make_latest: ${{ env.MAKE_LATEST }}
+          files: ${{ env.JAR_FILES }}
+          generate_release_notes: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing artifacts to Maven and creating GitHub releases, as well as adding IntelliJ IDEA VCS configuration to the repository. The main focus is on automating the release and publication process for the project.

**CI/CD Automation:**

* Added a new workflow file `.github/workflows/publish.yml` that builds all modules, publishes them to Maven, and creates a GitHub release with the generated JAR files. This workflow supports both snapshot and release versions, handles release flags, and uses secrets for authentication.

**IDE Configuration:**

* Added `.idea/vcs.xml` to configure Git as the version control system and enforce commit message inspections in IntelliJ IDEA.