### PR TITLE
Feat/71 chat disabling

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+
 buildscript {
     repositories {
         gradlePluginPortal()
@@ -11,4 +13,8 @@ buildscript {
 allprojects {
     group = "dev.slne.surf.chat"
     version = findProperty("version")!!
+}
+
+tasks.withType<ShadowJar> {
+    archiveClassifier = null
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-
 buildscript {
     repositories {
         gradlePluginPortal()
@@ -13,8 +11,4 @@ buildscript {
 allprojects {
     group = "dev.slne.surf.chat"
     version = findProperty("version")!!
-}
-
-tasks.withType<ShadowJar> {
-    archiveClassifier = null
 }

--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/SurfChatApi.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/SurfChatApi.kt
@@ -5,6 +5,7 @@ import dev.slne.surf.chat.api.entity.User
 import dev.slne.surf.chat.api.entry.HistoryEntry
 import dev.slne.surf.chat.api.entry.HistoryFilter
 import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.surfapi.core.api.util.requiredService
 import it.unimi.dsi.fastutil.objects.ObjectSet
 import net.kyori.adventure.chat.SignedMessage
@@ -34,7 +35,7 @@ interface SurfChatApi {
         sender: User,
         receiver: User? = null,
         sentAt: Long = System.currentTimeMillis(),
-        server: String = "unspecified",
+        server: ChatServer = ChatServer.default(),
         channel: Channel? = null,
         signedMessage: SignedMessage? = null
     )

--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/entry/HistoryEntry.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/entry/HistoryEntry.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.chat.api.entry
 
 import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
 import java.util.*
 
 /**
@@ -23,7 +24,7 @@ interface HistoryEntry {
     val messageType: MessageType
     val sentAt: Long
     val message: String
-    val server: String
+    val server: ChatServer
     val channel: String?
     val deletedBy: String?
 }
@@ -50,7 +51,7 @@ interface HistoryFilter {
     val messageType: MessageType?
     val range: Long?
     val messageLike: String?
-    val server: String?
+    val server: ChatServer?
     val channel: String?
     val deletedBy: String?
     val type: MessageType?

--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/server/ChatServer.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/server/ChatServer.kt
@@ -30,5 +30,12 @@ interface ChatServer {
             override val internalName: String
                 get() = internalName
         }
+
+        fun of(name: String, internalName: String) = object : ChatServer {
+            override val name: String
+                get() = name
+            override val internalName: String
+                get() = internalName
+        }
     }
 }

--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/server/ChatServer.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/server/ChatServer.kt
@@ -1,17 +1,34 @@
 package dev.slne.surf.chat.api.server
 
 interface ChatServer {
-  /**
-   * The user-facing display name of the chat server.
-   * This is intended to be shown to end users.
-   */
-  val name: String
-  /**
-   * The internal name of the chat server, used for identification within the system.
-   *
-   * Unlike [name], which is intended for display to end users and may be localized or formatted for presentation,
-   * [internalName] is a stable, unique identifier used internally (e.g., for configuration, logging, or referencing servers in code).
-   * Use [internalName] when you need a value that does not change and is not user-facing.
-   */
-  val internalName: String
+    /**
+     * The user-facing display name of the chat server.
+     * This is intended to be shown to end users.
+     */
+    val name: String
+
+    /**
+     * The internal name of the chat server, used for identification within the system.
+     *
+     * Unlike [name], which is intended for display to end users and may be localized or formatted for presentation,
+     * [internalName] is a stable, unique identifier used internally (e.g., for configuration, logging, or referencing servers in code).
+     * Use [internalName] when you need a value that does not change and is not user-facing.
+     */
+    val internalName: String
+
+    companion object {
+        fun default() = object : ChatServer {
+            override val name: String
+                get() = "Unspecified"
+            override val internalName: String
+                get() = "null"
+        }
+
+        fun of(internalName: String) = object : ChatServer {
+            override val name: String
+                get() = internalName.lowercase().replaceFirstChar { it.uppercase() }
+            override val internalName: String
+                get() = internalName
+        }
+    }
 }

--- a/surf-chat-bukkit/build.gradle.kts
+++ b/surf-chat-bukkit/build.gradle.kts
@@ -19,7 +19,3 @@ surfPaperPluginApi {
 
     authors.add("red")
 }
-
-tasks.shadowJar {
-    archiveFileName = "surf-chat-bukkit-${project.version}.jar"
-}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.chat.bukkit.config.ChatServerProviderConfig
 import dev.slne.surf.chat.bukkit.config.ConnectionMessageConfigProvider
 import dev.slne.surf.chat.core.service.databaseService
 import dev.slne.surf.chat.core.service.denylistService
+import dev.slne.surf.chat.core.service.functionalityService
 import org.bukkit.plugin.java.JavaPlugin
 
 val plugin get() = JavaPlugin.getPlugin(BukkitMain::class.java)
@@ -25,6 +26,7 @@ class BukkitMain : SuspendingJavaPlugin() {
 
         launch {
             denylistService.fetch()
+            functionalityService.fetch(server)
         }
     }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
@@ -4,17 +4,15 @@ import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.bukkit.config.ChatMotdConfigProvider
+import dev.slne.surf.chat.bukkit.config.ChatServerProviderConfig
 import dev.slne.surf.chat.bukkit.config.ConnectionMessageConfigProvider
 import dev.slne.surf.chat.core.service.databaseService
 import dev.slne.surf.chat.core.service.denylistService
 import org.bukkit.plugin.java.JavaPlugin
-import java.util.*
 
 val plugin get() = JavaPlugin.getPlugin(BukkitMain::class.java)
 
 class BukkitMain : SuspendingJavaPlugin() {
-    var server = Optional.empty<ChatServer>()
-
     override fun onLoad() {
         databaseService.establishConnection(plugin.dataPath)
         databaseService.createTables()
@@ -35,5 +33,11 @@ class BukkitMain : SuspendingJavaPlugin() {
     }
 
     val connectionMessageConfig = ConnectionMessageConfigProvider()
+
     val chatMotdConfig = ChatMotdConfigProvider()
+    val chatServerConfig = ChatServerProviderConfig()
+    var server = ChatServer.of(
+        plugin.chatServerConfig.config().internalName,
+        plugin.chatServerConfig.config().displayName
+    )
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.chat.bukkit
 
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
 import com.github.shynixn.mccoroutine.folia.launch
+import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.bukkit.config.ChatMotdConfigProvider
 import dev.slne.surf.chat.bukkit.config.ConnectionMessageConfigProvider
 import dev.slne.surf.chat.core.service.databaseService
@@ -12,7 +13,7 @@ import java.util.*
 val plugin get() = JavaPlugin.getPlugin(BukkitMain::class.java)
 
 class BukkitMain : SuspendingJavaPlugin() {
-    var serverName = Optional.empty<String>()
+    var server = Optional.empty<ChatServer>()
 
     override fun onLoad() {
         databaseService.establishConnection(plugin.dataPath)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.chat.bukkit
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.chat.api.server.ChatServer
+import dev.slne.surf.chat.bukkit.config.AutoDisablingConfigProvider
 import dev.slne.surf.chat.bukkit.config.ChatMotdConfigProvider
 import dev.slne.surf.chat.bukkit.config.ChatServerProviderConfig
 import dev.slne.surf.chat.bukkit.config.ConnectionMessageConfigProvider
@@ -35,9 +36,10 @@ class BukkitMain : SuspendingJavaPlugin() {
     }
 
     val connectionMessageConfig = ConnectionMessageConfigProvider()
-
     val chatMotdConfig = ChatMotdConfigProvider()
     val chatServerConfig = ChatServerProviderConfig()
+    val autoDisablingConfig = AutoDisablingConfigProvider()
+
     var server = ChatServer.of(
         plugin.chatServerConfig.config().internalName,
         plugin.chatServerConfig.config().displayName

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/TeamchatCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/TeamchatCommand.kt
@@ -6,6 +6,7 @@ import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.greedyStringArgument
 import dev.jorel.commandapi.kotlindsl.playerExecutor
 import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.bukkit.message.MessageDataImpl
 import dev.slne.surf.chat.bukkit.message.MessageFormatterImpl
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
@@ -34,7 +35,7 @@ fun teamchatCommand() = commandAPICommand("teamchat", plugin) {
             null,
             System.currentTimeMillis(),
             messageId,
-            plugin.serverName.getOrNull() ?: "Error",
+            plugin.server.getOrNull() ?: ChatServer.default(),
             null,
             null,
             MessageType.TEAM

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/TeamchatCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/TeamchatCommand.kt
@@ -18,7 +18,6 @@ import dev.slne.surf.chat.core.service.historyService
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
 import java.util.*
-import kotlin.jvm.optionals.getOrNull
 
 fun teamchatCommand() = commandAPICommand("teamchat", plugin) {
     withAliases("tc")
@@ -35,7 +34,10 @@ fun teamchatCommand() = commandAPICommand("teamchat", plugin) {
             null,
             System.currentTimeMillis(),
             messageId,
-            plugin.server.getOrNull() ?: ChatServer.default(),
+            ChatServer.of(
+                plugin.chatServerConfig.config().internalName,
+                plugin.chatServerConfig.config().displayName
+            ),
             null,
             null,
             MessageType.TEAM

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChatServerArgument.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChatServerArgument.kt
@@ -1,0 +1,30 @@
+package dev.slne.surf.chat.bukkit.command.argument
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.StringArgument
+import dev.slne.surf.chat.api.server.ChatServer
+import dev.slne.surf.chat.bukkit.plugin
+import kotlin.jvm.optionals.getOrNull
+
+class ChatServerArgument(nodeName: String) :
+    CustomArgument<ChatServer, String>(StringArgument(nodeName), { info ->
+        ChatServer.of(info.input)
+    }) {
+    init {
+        plugin.server.getOrNull()?.internalName?.let { serverName ->
+            replaceSuggestions(ArgumentSuggestions.strings {
+                arrayOf(serverName)
+            })
+        }
+    }
+}
+
+inline fun CommandAPICommand.chatServerArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandAPICommand =
+    withArguments(ChatServerArgument(nodeName).setOptional(optional).apply(block))

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChatServerArgument.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChatServerArgument.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.chat.bukkit.command.argument
 
 import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
 import dev.jorel.commandapi.arguments.CustomArgument
 import dev.jorel.commandapi.arguments.StringArgument
 import dev.slne.surf.chat.api.server.ChatServer
@@ -12,7 +13,9 @@ class ChatServerArgument(nodeName: String) :
         ChatServer.of(info.input)
     }) {
     init {
-        arrayOf(plugin.server.internalName)
+        replaceSuggestions(ArgumentSuggestions.stringCollection {
+            listOf(plugin.server.internalName)
+        })
     }
 }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChatServerArgument.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/ChatServerArgument.kt
@@ -2,23 +2,17 @@ package dev.slne.surf.chat.bukkit.command.argument
 
 import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.arguments.Argument
-import dev.jorel.commandapi.arguments.ArgumentSuggestions
 import dev.jorel.commandapi.arguments.CustomArgument
 import dev.jorel.commandapi.arguments.StringArgument
 import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.bukkit.plugin
-import kotlin.jvm.optionals.getOrNull
 
 class ChatServerArgument(nodeName: String) :
     CustomArgument<ChatServer, String>(StringArgument(nodeName), { info ->
         ChatServer.of(info.input)
     }) {
     init {
-        plugin.server.getOrNull()?.internalName?.let { serverName ->
-            replaceSuggestions(ArgumentSuggestions.strings {
-                arrayOf(serverName)
-            })
-        }
+        arrayOf(plugin.server.internalName)
     }
 }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelInviteCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/channel/ChannelInviteCommand.kt
@@ -10,7 +10,8 @@ import dev.slne.surf.chat.api.entity.User
 import dev.slne.surf.chat.bukkit.command.argument.userArgument
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
-import dev.slne.surf.chat.bukkit.util.components
+import dev.slne.surf.chat.bukkit.util.appendInviteAccept
+import dev.slne.surf.chat.bukkit.util.appendInviteDecline
 import dev.slne.surf.chat.bukkit.util.sendText
 import dev.slne.surf.chat.bukkit.util.user
 import dev.slne.surf.chat.core.service.channelService
@@ -87,8 +88,8 @@ fun CommandAPICommand.channelInviteCommand() = subcommand("invite") {
                     variableValue(channel.channelName)
                     info(" eingeladen. ")
 
-                    append(components.inviteAccept(channel))
-                    append(components.inviteDecline(channel))
+                    appendInviteAccept(channel)
+                    appendInviteDecline(channel)
                 }
             }
         }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatCommand.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.chat.bukkit.command.surfchat
 
 import dev.jorel.commandapi.kotlindsl.commandAPICommand
+import dev.slne.surf.chat.bukkit.command.surfchat.functionality.functionalityCommand
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
 
@@ -11,4 +12,5 @@ fun surfChatCommand() = commandAPICommand("surfchat", plugin) {
     surfChatLookupCommand()
     surfChatLookupHelpCommand()
     surfChatReloadCommand()
+    functionalityCommand()
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatLookupCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatLookupCommand.kt
@@ -10,6 +10,7 @@ import dev.jorel.commandapi.kotlindsl.subcommand
 import dev.slne.surf.chat.api.entry.HistoryEntry
 import dev.slne.surf.chat.api.entry.HistoryFilter
 import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.bukkit.util.unixTime
@@ -129,7 +130,7 @@ fun CommandAPICommand.surfChatLookupCommand() = subcommand("lookup") {
                                 append(CommonComponents.EM_DASH)
                                 appendSpace()
                                 variableKey("Server: ")
-                                variableValue(entry.server)
+                                variableValue(entry.server.name)
                                 appendNewline()
                                 append(CommonComponents.EM_DASH)
                                 appendSpace()
@@ -189,8 +190,9 @@ private suspend fun Map<String, String>.parseFilters(): HistoryFilter {
             this@parseFilters["--range"]?.let { parseRangeToMillis(it) }
         override val messageLike: String? =
             this@parseFilters["--message"]
-        override val server: String? =
-            this@parseFilters["--server"]
+        override val server: ChatServer? = this@parseFilters["--server"]?.let {
+            ChatServer.of(it)
+        }
         override val channel: String? =
             this@parseFilters["--channel"]
         override val deletedBy: String? =

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatReloadCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatReloadCommand.kt
@@ -17,6 +17,7 @@ fun CommandAPICommand.surfChatReloadCommand() = subcommand("reload") {
             plugin.connectionMessageConfig.reload()
             plugin.chatMotdConfig.reload()
             plugin.chatServerConfig.reload()
+            plugin.autoDisablingConfig.reload()
 
             ConnectListener.ALREADY_REQUESTED = false
         }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatReloadCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatReloadCommand.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.chat.bukkit.command.surfchat
 import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.kotlindsl.anyExecutor
 import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.bukkit.listener.ConnectListener
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.bukkit.util.coloredComponent
@@ -11,10 +12,13 @@ import kotlin.system.measureTimeMillis
 
 fun CommandAPICommand.surfChatReloadCommand() = subcommand("reload") {
     withPermission(SurfChatPermissionRegistry.COMMAND_SURFCHAT_RELOAD)
-    anyExecutor { executor, args ->
+    anyExecutor { executor, _ ->
         val ms = measureTimeMillis {
             plugin.connectionMessageConfig.reload()
             plugin.chatMotdConfig.reload()
+            plugin.chatServerConfig.reload()
+
+            ConnectListener.ALREADY_REQUESTED = false
         }
 
         executor.sendText {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityChangeCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityChangeCommand.kt
@@ -1,0 +1,48 @@
+package dev.slne.surf.chat.bukkit.command.surfchat.functionality
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.api.server.ChatServer
+import dev.slne.surf.chat.bukkit.command.argument.chatServerArgument
+import dev.slne.surf.chat.bukkit.command.argument.niceToggleArgument
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.core.service.functionalityService
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import kotlin.jvm.optionals.getOrNull
+
+fun CommandAPICommand.functionalityChangeCommand() = subcommand("change") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_SURFCHAT_FUNCTIONALITY_TOGGLE)
+    niceToggleArgument("toggle")
+    chatServerArgument("internalServerName", true)
+    anyExecutor { player, args ->
+        val toggle: Boolean by args
+        val internalServerName: ChatServer? by args
+        val server = plugin.server.getOrNull() ?: internalServerName ?: run {
+            player.sendText {
+                appendPrefix()
+                error("Ein interner Fehler ist aufgetreten. Bitte gebe den Server Namen an. /surfchat functionality change <true|false> <internalServerName>")
+            }
+            return@anyExecutor
+        }
+
+        plugin.launch {
+            if (toggle) {
+                functionalityService.enableLocalChat(server)
+                player.sendText {
+                    appendPrefix()
+                    success("Der Chat wurde aktiviert.")
+                }
+            } else {
+                functionalityService.disableLocalChat(server)
+                player.sendText {
+                    appendPrefix()
+                    success("Der Chat wurde deaktiviert.")
+                }
+            }
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityChangeCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityChangeCommand.kt
@@ -5,34 +5,22 @@ import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.kotlindsl.anyExecutor
 import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.subcommand
-import dev.slne.surf.chat.api.server.ChatServer
-import dev.slne.surf.chat.bukkit.command.argument.chatServerArgument
 import dev.slne.surf.chat.bukkit.command.argument.niceToggleArgument
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.core.service.functionalityService
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import org.bukkit.Bukkit
-import kotlin.jvm.optionals.getOrNull
 
 fun CommandAPICommand.functionalityChangeCommand() = subcommand("change") {
     withPermission(SurfChatPermissionRegistry.COMMAND_SURFCHAT_FUNCTIONALITY_TOGGLE)
     niceToggleArgument("toggle")
-    chatServerArgument("internalServerName", true)
     anyExecutor { player, args ->
         val toggle: Boolean by args
-        val internalServerName: ChatServer? by args
-        val server = plugin.server.getOrNull() ?: internalServerName ?: run {
-            player.sendText {
-                appendPrefix()
-                error("Ein interner Fehler ist aufgetreten. Bitte gebe den Server Namen an. /surfchat functionality change <true|false> <internalServerName>")
-            }
-            return@anyExecutor
-        }
 
         plugin.launch {
             if (toggle) {
-                functionalityService.enableLocalChat(server)
+                functionalityService.enableLocalChat(plugin.server)
                 player.sendText {
                     appendPrefix()
                     success("Der Chat wurde aktiviert.")
@@ -40,16 +28,16 @@ fun CommandAPICommand.functionalityChangeCommand() = subcommand("change") {
 
                 Bukkit.getOnlinePlayers()
                     .filter { it.hasPermission(SurfChatPermissionRegistry.TEAM_ACCESS) }.forEach {
-                    it.sendText {
-                        appendPrefix()
-                        variableValue(player.name)
-                        info(" hat den Chat für den Server ")
-                        variableValue(server.name)
-                        info(" aktiviert.")
+                        it.sendText {
+                            appendPrefix()
+                            variableValue(player.name)
+                            info(" hat den Chat für den Server ")
+                            variableValue(plugin.server.name)
+                            info(" aktiviert.")
+                        }
                     }
-                }
             } else {
-                functionalityService.disableLocalChat(server)
+                functionalityService.disableLocalChat(plugin.server)
                 player.sendText {
                     appendPrefix()
                     success("Der Chat wurde deaktiviert.")
@@ -57,14 +45,14 @@ fun CommandAPICommand.functionalityChangeCommand() = subcommand("change") {
 
                 Bukkit.getOnlinePlayers()
                     .filter { it.hasPermission(SurfChatPermissionRegistry.TEAM_ACCESS) }.forEach {
-                    it.sendText {
-                        appendPrefix()
-                        variableValue(player.name)
-                        info(" hat den Chat für den Server ")
-                        variableValue(server.name)
-                        info(" deaktiviert.")
+                        it.sendText {
+                            appendPrefix()
+                            variableValue(player.name)
+                            info(" hat den Chat für den Server ")
+                            variableValue(plugin.server.name)
+                            info(" deaktiviert.")
+                        }
                     }
-                }
             }
         }
     }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityChangeCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityChangeCommand.kt
@@ -12,6 +12,7 @@ import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.core.service.functionalityService
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import org.bukkit.Bukkit
 import kotlin.jvm.optionals.getOrNull
 
 fun CommandAPICommand.functionalityChangeCommand() = subcommand("change") {
@@ -36,11 +37,33 @@ fun CommandAPICommand.functionalityChangeCommand() = subcommand("change") {
                     appendPrefix()
                     success("Der Chat wurde aktiviert.")
                 }
+
+                Bukkit.getOnlinePlayers()
+                    .filter { it.hasPermission(SurfChatPermissionRegistry.TEAM_ACCESS) }.forEach {
+                    it.sendText {
+                        appendPrefix()
+                        variableValue(player.name)
+                        info(" hat den Chat für den Server ")
+                        variableValue(server.name)
+                        info(" aktiviert.")
+                    }
+                }
             } else {
                 functionalityService.disableLocalChat(server)
                 player.sendText {
                     appendPrefix()
                     success("Der Chat wurde deaktiviert.")
+                }
+
+                Bukkit.getOnlinePlayers()
+                    .filter { it.hasPermission(SurfChatPermissionRegistry.TEAM_ACCESS) }.forEach {
+                    it.sendText {
+                        appendPrefix()
+                        variableValue(player.name)
+                        info(" hat den Chat für den Server ")
+                        variableValue(server.name)
+                        info(" deaktiviert.")
+                    }
                 }
             }
         }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityCommand.kt
@@ -1,0 +1,13 @@
+package dev.slne.surf.chat.bukkit.command.surfchat.functionality
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+
+fun CommandAPICommand.functionalityCommand() = subcommand("functionality") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_SURFCHAT_FUNCTIONALITY)
+
+    functionalityStatusCommand()
+    functionalityChangeCommand()
+    functionalityListCommand()
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityListCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityListCommand.kt
@@ -1,0 +1,64 @@
+package dev.slne.surf.chat.bukkit.command.surfchat.functionality
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.integerArgument
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.bukkit.util.appendStatusIcon
+import dev.slne.surf.chat.core.service.functionalityService
+import dev.slne.surf.surfapi.core.api.messages.CommonComponents
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import dev.slne.surf.surfapi.core.api.messages.pagination.Pagination
+import net.kyori.adventure.text.format.TextDecoration
+
+fun CommandAPICommand.functionalityListCommand() = subcommand("list") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_SURFCHAT_FUNCTIONALITY_LIST)
+    integerArgument("page", 1, Int.MAX_VALUE, true)
+    anyExecutor { player, args ->
+        val page: Int by args
+        val pagination = Pagination<FunctionalityStatusEntry> {
+            title { primary("Chat Funktionalität", TextDecoration.BOLD) }
+            rowRenderer { row, _ ->
+                listOf(
+                    buildText {
+                        append(CommonComponents.EM_DASH)
+                        appendSpace()
+                        variableKey(row.name)
+                        spacer(":")
+                        appendSpace()
+                        appendStatusIcon(row.status)
+                    }
+                )
+            }
+        }
+
+        player.sendText {
+            appendPrefix()
+            info("Lädt...")
+        }
+
+        plugin.launch {
+            val content = functionalityService.getAllServers().map {
+                FunctionalityStatusEntry(
+                    it.name,
+                    functionalityService.isEnabledForServer(it)
+                )
+            }
+
+            player.sendText {
+                append(pagination.renderComponent(content, page))
+            }
+        }
+    }
+}
+
+
+private data class FunctionalityStatusEntry(
+    val name: String,
+    val status: Boolean
+)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityListCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityListCommand.kt
@@ -3,7 +3,6 @@ package dev.slne.surf.chat.bukkit.command.surfchat.functionality
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.kotlindsl.anyExecutor
-import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.integerArgument
 import dev.jorel.commandapi.kotlindsl.subcommand
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
@@ -20,7 +19,7 @@ fun CommandAPICommand.functionalityListCommand() = subcommand("list") {
     withPermission(SurfChatPermissionRegistry.COMMAND_SURFCHAT_FUNCTIONALITY_LIST)
     integerArgument("page", 1, Int.MAX_VALUE, true)
     anyExecutor { player, args ->
-        val page: Int by args
+        val page = args.getOrDefaultUnchecked("page", 1)
         val pagination = Pagination<FunctionalityStatusEntry> {
             title { primary("Chat Funktionalität", TextDecoration.BOLD) }
             rowRenderer { row, _ ->

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityStatusCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityStatusCommand.kt
@@ -1,0 +1,20 @@
+package dev.slne.surf.chat.bukkit.command.surfchat.functionality
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+import dev.slne.surf.chat.core.service.functionalityService
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+
+fun CommandAPICommand.functionalityStatusCommand() = subcommand("status") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_SURFCHAT_FUNCTIONALITY_STATUS)
+    anyExecutor { player, _ ->
+        player.sendText {
+            appendPrefix()
+            info("Der Chat ist derzeit ")
+            variableValue(if (functionalityService.isLocalChatEnabled()) "aktiviert" else "deaktiviert")
+            info(".")
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/AutoDisablingConfig.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/AutoDisablingConfig.kt
@@ -1,0 +1,9 @@
+package dev.slne.surf.chat.bukkit.config
+
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+
+@ConfigSerializable
+data class AutoDisablingConfig(
+    val enabled: Boolean = false,
+    val maximumPlayersBeforeDisable: Int = 50,
+)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/AutoDisablingConfigProvider.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/AutoDisablingConfigProvider.kt
@@ -1,0 +1,27 @@
+package dev.slne.surf.chat.bukkit.config
+
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.surfapi.core.api.config.manager.SpongeConfigManager
+import dev.slne.surf.surfapi.core.api.config.surfConfigApi
+
+class AutoDisablingConfigProvider {
+    private val configManager: SpongeConfigManager<AutoDisablingConfig>
+
+    init {
+        surfConfigApi.createSpongeYmlConfig(
+            AutoDisablingConfig::class.java,
+            plugin.dataPath,
+            "auto-disabling.yml"
+        )
+        configManager = surfConfigApi.getSpongeConfigManagerForConfig(
+            AutoDisablingConfig::class.java
+        )
+        reload()
+    }
+
+    fun reload() {
+        configManager.reloadFromFile()
+    }
+
+    fun config() = configManager.config
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/ChatServerConfig.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/ChatServerConfig.kt
@@ -1,9 +1,13 @@
 package dev.slne.surf.chat.bukkit.config
 
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import org.spongepowered.configurate.objectmapping.meta.Comment
 
 @ConfigSerializable
 data class ChatServerConfig(
-    var internalName: String,
-    val displayName: String
+    @param:Comment("Internal name of this server, used for identifying the server in the network. This name will automatically requested from the proxy when a player connects to the server.")
+    var internalName: String = "unspecified",
+    var displayName: String = CONFIG_DISPLAY_DEFAULT
 )
+
+val CONFIG_DISPLAY_DEFAULT = "Unspecified Server"

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/ChatServerConfig.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/ChatServerConfig.kt
@@ -10,4 +10,4 @@ data class ChatServerConfig(
     var displayName: String = CONFIG_DISPLAY_DEFAULT
 )
 
-val CONFIG_DISPLAY_DEFAULT = "Unspecified Server"
+const val CONFIG_DISPLAY_DEFAULT = "Unspecified Server"

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/ChatServerConfig.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/ChatServerConfig.kt
@@ -1,0 +1,9 @@
+package dev.slne.surf.chat.bukkit.config
+
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+
+@ConfigSerializable
+data class ChatServerConfig(
+    var internalName: String,
+    val displayName: String
+)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/ChatServerProviderConfig.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/ChatServerProviderConfig.kt
@@ -1,0 +1,32 @@
+package dev.slne.surf.chat.bukkit.config
+
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.surfapi.core.api.config.manager.SpongeConfigManager
+import dev.slne.surf.surfapi.core.api.config.surfConfigApi
+
+class ChatServerProviderConfig {
+    private val configManager: SpongeConfigManager<ChatServerConfig>
+
+    init {
+        surfConfigApi.createSpongeYmlConfig(
+            ChatServerConfig::class.java,
+            plugin.dataPath,
+            "chat-server.yml"
+        )
+        configManager = surfConfigApi.getSpongeConfigManagerForConfig(
+            ChatServerConfig::class.java
+        )
+        reload()
+    }
+
+    fun edit(action: ChatServerConfig.() -> Unit) {
+        configManager.config = configManager.config.apply { action() }
+        configManager.save()
+    }
+
+    fun reload() {
+        configManager.reloadFromFile()
+    }
+
+    fun config() = configManager.config
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
@@ -16,6 +16,7 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import io.papermc.paper.event.player.AsyncChatEvent
 import net.kyori.adventure.text.TextReplacementConfig
 import org.bukkit.Bukkit
+import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import java.util.*
@@ -42,6 +43,15 @@ class AsyncChatListener : Listener {
             player.sendText {
                 appendWarningPrefix()
                 error("Der Chat ist vorübergehend deaktiviert.")
+            }
+            event.cancel()
+            return
+        }
+
+        if (this.checkAutoDisabling(player)) {
+            player.sendText {
+                appendWarningPrefix()
+                error("Du kannst zurzeit nicht schreiben.")
             }
             event.cancel()
             return
@@ -136,4 +146,9 @@ class AsyncChatListener : Listener {
             )
         }
     }
+
+    fun checkAutoDisabling(player: Player): Boolean =
+        !player.hasPermission(SurfChatPermissionRegistry.AUTO_CHAT_DISABLING_BYPASS)
+                && Bukkit.getOnlinePlayers().size > plugin.autoDisablingConfig.config().maximumPlayersBeforeDisable
+                && plugin.autoDisablingConfig.config().enabled
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
@@ -47,7 +47,7 @@ class AsyncChatListener : Listener {
         ) {
             player.sendText {
                 appendWarningPrefix()
-                warning("Der Chat ist vorübergehend deaktiviert.")
+                error("Der Chat ist vorübergehend deaktiviert.")
             }
             event.cancel()
             return

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
@@ -1,9 +1,7 @@
 package dev.slne.surf.chat.bukkit.listener
 
 import com.github.shynixn.mccoroutine.folia.launch
-
 import dev.slne.surf.chat.api.message.MessageType
-import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.bukkit.message.MessageDataImpl
 import dev.slne.surf.chat.bukkit.message.MessageFormatterImpl
 import dev.slne.surf.chat.bukkit.message.MessageValidatorImpl
@@ -15,16 +13,12 @@ import dev.slne.surf.chat.core.service.functionalityService
 import dev.slne.surf.chat.core.service.historyService
 import dev.slne.surf.chat.core.service.spyService
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
-
 import io.papermc.paper.event.player.AsyncChatEvent
 import net.kyori.adventure.text.TextReplacementConfig
-
 import org.bukkit.Bukkit
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
-
 import java.util.*
-import kotlin.jvm.optionals.getOrNull
 
 class AsyncChatListener : Listener {
     private val channelExceptPattern =
@@ -38,7 +32,7 @@ class AsyncChatListener : Listener {
         val message = event.message()
         val messageId = UUID.randomUUID()
         val messageValidator = MessageValidatorImpl.componentValidator(message)
-        val server = plugin.server.getOrNull() ?: ChatServer.default()
+        val server = plugin.server
         val plainMessage = message.plainText()
 
         if (!functionalityService.isLocalChatEnabled() && !player.hasPermission(

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ConnectListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ConnectListener.kt
@@ -18,7 +18,7 @@ class ConnectListener : Listener {
     fun onJoin(event: PlayerJoinEvent) {
         plugin.launch(Dispatchers.IO) {
 
-            if (plugin.serverName.isEmpty) {
+            if (plugin.server.isEmpty) {
                 delay(1000)
                 pluginMessageSender(Constants.CHANNEL_SERVER_REQUEST, event.player) {
                     writeUTF("Requesting data...")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ConnectListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ConnectListener.kt
@@ -18,11 +18,12 @@ class ConnectListener : Listener {
     fun onJoin(event: PlayerJoinEvent) {
         plugin.launch(Dispatchers.IO) {
 
-            if (plugin.server.isEmpty) {
+            if (!ALREADY_REQUESTED) {
                 delay(1000)
                 pluginMessageSender(Constants.CHANNEL_SERVER_REQUEST, event.player) {
                     writeUTF("Requesting data...")
                 }
+                ALREADY_REQUESTED = true
             }
         }
 
@@ -48,5 +49,9 @@ class ConnectListener : Listener {
                 )
             }
         }
+    }
+
+    companion object {
+        var ALREADY_REQUESTED = false
     }
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/DirectMessageListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/DirectMessageListener.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.chat.bukkit.listener
 
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.bukkit.message.MessageDataImpl
 import dev.slne.surf.chat.bukkit.message.MessageFormatterImpl
 import dev.slne.surf.chat.bukkit.plugin
@@ -51,7 +52,7 @@ class DirectMessageListener : PluginMessageListener {
                     userService.getOfflineUser(targetUuid, targetName),
                     sentAt,
                     messageUuid,
-                    serverName,
+                    ChatServer.of(serverName),
                     null,
                     null,
                     MessageType.DIRECT

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ServerResponseListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ServerResponseListener.kt
@@ -6,7 +6,6 @@ import dev.slne.surf.chat.core.Constants
 import org.bukkit.entity.Player
 import org.bukkit.plugin.messaging.PluginMessageListener
 import java.io.DataInputStream
-import java.util.*
 
 class ServerResponseListener : PluginMessageListener {
     override fun onPluginMessageReceived(
@@ -20,7 +19,13 @@ class ServerResponseListener : PluginMessageListener {
 
         message.inputStream().use { byteSteam ->
             DataInputStream(byteSteam).use { input ->
-                plugin.server = Optional.of(ChatServer.of(input.readUTF()))
+                plugin.chatServerConfig.edit {
+                    internalName = input.readUTF()
+                }
+                plugin.server = ChatServer.of(
+                    plugin.chatServerConfig.config().displayName,
+                    plugin.chatServerConfig.config().internalName
+                )
             }
         }
     }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ServerResponseListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ServerResponseListener.kt
@@ -1,5 +1,6 @@
 package dev.slne.surf.chat.bukkit.listener
 
+import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.core.Constants
 import org.bukkit.entity.Player
@@ -19,7 +20,7 @@ class ServerResponseListener : PluginMessageListener {
 
         message.inputStream().use { byteSteam ->
             DataInputStream(byteSteam).use { input ->
-                plugin.serverName = Optional.of(input.readUTF())
+                plugin.server = Optional.of(ChatServer.of(input.readUTF()))
             }
         }
     }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ServerResponseListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ServerResponseListener.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.chat.bukkit.listener
 
 import dev.slne.surf.chat.api.server.ChatServer
+import dev.slne.surf.chat.bukkit.config.CONFIG_DISPLAY_DEFAULT
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.core.Constants
 import org.bukkit.entity.Player
@@ -19,8 +20,13 @@ class ServerResponseListener : PluginMessageListener {
 
         message.inputStream().use { byteSteam ->
             DataInputStream(byteSteam).use { input ->
+                val received = input.readUTF()
                 plugin.chatServerConfig.edit {
-                    internalName = input.readUTF()
+                    internalName = received
+
+                    if (displayName == CONFIG_DISPLAY_DEFAULT) {
+                        displayName = received.replaceFirstChar { it.uppercase() }
+                    }
                 }
                 plugin.server = ChatServer.of(
                     plugin.chatServerConfig.config().displayName,

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/message/MessageDataImpl.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/message/MessageDataImpl.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.chat.bukkit.message
 import dev.slne.surf.chat.api.channel.Channel
 import dev.slne.surf.chat.api.entity.User
 import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.core.message.MessageData
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
@@ -14,7 +15,7 @@ data class MessageDataImpl(
     override val receiver: User?,
     override val sentAt: Long,
     override val messageUuid: UUID,
-    override val server: String,
+    override val server: ChatServer,
     override val channel: Channel? = null,
     override val signedMessage: SignedMessage? = null,
     override val type: MessageType

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
@@ -9,6 +9,7 @@ object SurfChatPermissionRegistry : PermissionRegistry() {
 
     val FILTER_BYPASS = create("$PREFIX.filter.bypass")
     val TEAM_ACCESS = create(Constants.TEAM_PERMISSION)
+    val AUTO_CHAT_DISABLING_BYPASS = create("$PREFIX.disabling.bypass")
 
     val COMMAND_SURFCHAT = create("$PREFIX_COMMAND.surfchat")
     val COMMAND_SURFCHAT_RELOAD = create("$PREFIX_COMMAND.surfchat.reload")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
@@ -15,20 +15,27 @@ object SurfChatPermissionRegistry : PermissionRegistry() {
     val COMMAND_SURFCHAT_DELETE = create("$PREFIX_COMMAND.surfchat.delete")
     val COMMAND_SURFCHAT_TELEPORT = create("$PREFIX_COMMAND.surfchat.teleport")
     val COMMAND_SURFCHAT_LOOKUP = create("$PREFIX_COMMAND.surfchat.lookup")
+
+    val COMMAND_SURFCHAT_FUNCTIONALITY = create("$PREFIX_COMMAND.surfchat.functionality")
+    val COMMAND_SURFCHAT_FUNCTIONALITY_TOGGLE =
+        create("$PREFIX_COMMAND.surfchat.functionality.toggle")
+    val COMMAND_SURFCHAT_FUNCTIONALITY_STATUS =
+        create("$PREFIX_COMMAND.surfchat.functionality.status")
+    val COMMAND_SURFCHAT_FUNCTIONALITY_LIST = create("$PREFIX_COMMAND.surfchat.functionality.list")
+
     val COMMAND_SURFCHAT_LOOKUP_HELP = create("$PREFIX_COMMAND.surfchat.lookup.help")
-
     val COMMAND_IGNORE = create("$PREFIX_COMMAND.ignore")
-    val COMMAND_IGNORE_LIST = create("$PREFIX_COMMAND.ignore.list")
 
+    val COMMAND_IGNORE_LIST = create("$PREFIX_COMMAND.ignore.list")
     val COMMAND_DENYLIST = create("$PREFIX_COMMAND.denylist")
     val COMMAND_DENYLIST_ADD = create("$PREFIX_COMMAND.denylist.add")
     val COMMAND_DENYLIST_REMOVE = create("$PREFIX_COMMAND.denylist.remove")
     val COMMAND_DENYLIST_LIST = create("$PREFIX_COMMAND.denylist.list")
+
     val COMMAND_DENYLIST_FETCH = create("$PREFIX_COMMAND.denylist.fetch")
-
     val COMMAND_DIRECT_SPY = create("$PREFIX_COMMAND.direct-spy")
-    val COMMAND_DIRECT_SPY_CLEAR = create("$PREFIX_COMMAND.direct-spy.clear")
 
+    val COMMAND_DIRECT_SPY_CLEAR = create("$PREFIX_COMMAND.direct-spy.clear")
     val COMMAND_CHANNEL = create("$PREFIX_COMMAND.channel")
     val COMMAND_CHANNEL_ACCEPT = create("$PREFIX_COMMAND.channel.accept")
     val COMMAND_CHANNEL_CREATE = create("$PREFIX_COMMAND.channel.create")
@@ -47,18 +54,19 @@ object SurfChatPermissionRegistry : PermissionRegistry() {
     val COMMAND_CHANNEL_REVOKE = create("$PREFIX_COMMAND.channel.uninvite")
     val COMMAND_CHANNEL_DECLINE = create("$PREFIX_COMMAND.channel.deny")
     val COMMAND_CHANNEL_MEMBERS = create("$PREFIX_COMMAND.channel.members")
-    val COMMAND_CHANNEL_VISIBILITY = create("$PREFIX_COMMAND.channel.mode")
 
+    val COMMAND_CHANNEL_VISIBILITY = create("$PREFIX_COMMAND.channel.mode")
     val COMMAND_CHANNEL_ADMIN = create("$PREFIX_COMMAND.channel.admin")
     val COMMAND_CHANNEL_ADMIN_MOVE = create("$PREFIX_COMMAND.channel.admin.move")
     val COMMAND_CHANNEL_ADMIN_JOIN = create("$PREFIX_COMMAND.channel.admin.join")
     val COMMAND_CHANNEL_ADMIN_DELETE = create("$PREFIX_COMMAND.channel.admin.delete")
     val COMMAND_CHANNEL_ADMIN_SPY = create("$PREFIX_COMMAND.channel.admin.spy")
-    val COMMAND_CHANNEL_ADMIN_SPY_CLEAR = create("$PREFIX_COMMAND.channel.admin.spy.clear")
 
+    val COMMAND_CHANNEL_ADMIN_SPY_CLEAR = create("$PREFIX_COMMAND.channel.admin.spy.clear")
     val COMMAND_SETTINGS = create("$PREFIX_COMMAND.settings")
     val COMMAND_SETTINGS_PING = create("$PREFIX_COMMAND.settings.ping")
     val COMMAND_SETTINGS_INVITES = create("$PREFIX_COMMAND.settings.invites")
+
     val COMMAND_SETTINGS_DIRECT_MESSAGES = create("$PREFIX_COMMAND.settings.direct-messages")
 
     val COMMAND_TEAMCHAT = create("$PREFIX_COMMAND.teamchat")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
@@ -13,6 +13,7 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 import net.kyori.adventure.text.event.ClickEvent
+import net.kyori.adventure.text.format.TextDecoration
 import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
@@ -134,7 +135,7 @@ fun SurfComponentBuilder.appendSpyIcon() = append {
 
 fun SurfComponentBuilder.appendWarningPrefix() = append {
     darkSpacer("[")
-    error("!")
+    error("!", TextDecoration.BOLD)
     darkSpacer("]")
     appendSpace()
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
@@ -60,7 +60,7 @@ fun SurfComponentBuilder.appendMessageData(messageData: MessageData) = append(bu
     variableValue(messageData.sentAt.unixTime())
     appendNewline()
     info("Gesendet auf Server ")
-    variableValue(messageData.server)
+    variableValue(messageData.server.name)
 })
 
 fun SurfComponentBuilder.appendName(player: Player) = append {
@@ -129,4 +129,11 @@ fun SurfComponentBuilder.appendSpyIcon() = append {
     spacer("[")
     info("SPY")
     spacer("]")
+}
+
+fun SurfComponentBuilder.appendWarningPrefix() = append {
+    darkSpacer("[")
+    error("!")
+    darkSpacer("]")
+    appendSpace()
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.core.message.MessageData
 import dev.slne.surf.chat.core.service.historyService
+import dev.slne.surf.surfapi.core.api.messages.Colors
 import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
@@ -134,6 +135,17 @@ fun SurfComponentBuilder.appendSpyIcon() = append {
 fun SurfComponentBuilder.appendWarningPrefix() = append {
     darkSpacer("[")
     error("!")
+    darkSpacer("]")
+    appendSpace()
+}
+
+fun SurfComponentBuilder.appendStatusIcon(status: Boolean) = append {
+    darkSpacer("[")
+    if (status) {
+        text("✔", Colors.GREEN)
+    } else {
+        text("✘", Colors.RED)
+    }
     darkSpacer("]")
     appendSpace()
 }

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/HistoryEntryImpl.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/HistoryEntryImpl.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.chat.core.entry
 import dev.slne.surf.chat.api.entry.HistoryEntry
 import dev.slne.surf.chat.api.entry.HistoryFilter
 import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
 import java.util.*
 
 data class HistoryEntryImpl(
@@ -11,7 +12,7 @@ data class HistoryEntryImpl(
     override val messageType: MessageType,
     override val sentAt: Long,
     override val message: String,
-    override val server: String,
+    override val server: ChatServer,
     override val deletedBy: String?,
     override val receiverUuid: UUID?,
     override val channel: String?
@@ -23,7 +24,7 @@ data class HistoryFilterImpl(
     override val messageType: MessageType?,
     override val range: Long?,
     override val messageLike: String?,
-    override val server: String?,
+    override val server: ChatServer?,
     override val deletedBy: String?,
     override val receiverUuid: UUID?,
     override val channel: String?,

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/message/MessageData.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/message/MessageData.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.chat.core.message
 import dev.slne.surf.chat.api.channel.Channel
 import dev.slne.surf.chat.api.entity.User
 import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
 import java.util.*
@@ -13,7 +14,7 @@ interface MessageData {
     val sender: User
     val receiver: User?
     val sentAt: Long
-    val server: String
+    val server: ChatServer
     val channel: Channel?
     val signedMessage: SignedMessage?
     val type: MessageType

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/FunctionalityService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/FunctionalityService.kt
@@ -11,6 +11,8 @@ interface FunctionalityService : ServiceUsingDatabase {
     suspend fun getAllEnabledServers(): ObjectSet<ChatServer>
     suspend fun getAllDisabledServers(): ObjectSet<ChatServer>
 
+    suspend fun fetch(localServer: ChatServer)
+
     suspend fun enableLocalChat(localServer: ChatServer)
     suspend fun toggleLocalChat(localServer: ChatServer): Boolean
     suspend fun disableLocalChat(localServer: ChatServer)

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/FunctionalityService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/FunctionalityService.kt
@@ -1,0 +1,24 @@
+package dev.slne.surf.chat.core.service
+
+import dev.slne.surf.chat.api.server.ChatServer
+import dev.slne.surf.surfapi.core.api.util.requiredService
+import it.unimi.dsi.fastutil.objects.ObjectSet
+
+interface FunctionalityService : ServiceUsingDatabase {
+    suspend fun isEnabledForServer(server: ChatServer): Boolean
+
+    suspend fun getAllServers(): ObjectSet<ChatServer>
+    suspend fun getAllEnabledServers(): ObjectSet<ChatServer>
+    suspend fun getAllDisabledServers(): ObjectSet<ChatServer>
+
+    suspend fun enableLocalChat(localServer: ChatServer)
+    suspend fun toggleLocalChat(localServer: ChatServer): Boolean
+    suspend fun disableLocalChat(localServer: ChatServer)
+    fun isLocalChatEnabled(): Boolean
+
+    companion object {
+        val INSTANCE = requiredService<FunctionalityService>()
+    }
+}
+
+val functionalityService get() = FunctionalityService.INSTANCE

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/FallbackSurfChatApi.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/FallbackSurfChatApi.kt
@@ -6,6 +6,7 @@ import dev.slne.surf.chat.api.channel.Channel
 import dev.slne.surf.chat.api.entity.User
 import dev.slne.surf.chat.api.entry.HistoryFilter
 import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.core.message.MessageData
 import dev.slne.surf.chat.core.service.channelService
 import dev.slne.surf.chat.core.service.historyService
@@ -23,7 +24,7 @@ class FallbackSurfChatApi : SurfChatApi, Services.Fallback {
         sender: User,
         receiver: User?,
         sentAt: Long,
-        server: String,
+        server: ChatServer,
         channel: Channel?,
         signedMessage: SignedMessage?
     ) {
@@ -38,7 +39,7 @@ class FallbackSurfChatApi : SurfChatApi, Services.Fallback {
                 get() = receiver
             override val sentAt: Long
                 get() = sentAt
-            override val server: String
+            override val server: ChatServer
                 get() = server
             override val channel: Channel?
                 get() = channel

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDatabaseService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDatabaseService.kt
@@ -21,6 +21,7 @@ class FallbackDatabaseService : DatabaseService, Services.Fallback {
         historyService.createTable()
         denylistService.createTable()
         ignoreService.createTable()
+        functionalityService.createTable()
     }
 
     override fun closeConnection() {

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDirectMessageService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDirectMessageService.kt
@@ -2,11 +2,11 @@ package dev.slne.surf.chat.fallback.service
 
 import com.google.auto.service.AutoService
 import dev.slne.surf.chat.core.service.DirectMessageService
+import dev.slne.surf.chat.fallback.table.DMSettingsTable
 import kotlinx.coroutines.Dispatchers
 import net.kyori.adventure.util.Services
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -15,31 +15,23 @@ import java.util.*
 
 @AutoService(DirectMessageService::class)
 class FallbackDirectMessageService : DirectMessageService, Services.Fallback {
-    object DirectMessageSettings : Table("chat_direct_messages") {
-        val userUuid =
-            varchar("user_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
-        val directMessagesEnabled = bool("direct_messages_enabled").default(true)
-
-        override val primaryKey = PrimaryKey(userUuid)
-    }
-
     override fun createTable() {
         transaction {
-            SchemaUtils.create(DirectMessageSettings)
+            SchemaUtils.create(DMSettingsTable)
         }
     }
 
     override suspend fun directMessagesEnabled(uuid: UUID) =
         newSuspendedTransaction(Dispatchers.IO) {
-            DirectMessageSettings.selectAll().where(DirectMessageSettings.userUuid eq uuid)
+            DMSettingsTable.selectAll().where(DMSettingsTable.userUuid eq uuid)
                 .firstOrNull()?.let {
-                    it[DirectMessageSettings.directMessagesEnabled]
+                    it[DMSettingsTable.directMessagesEnabled]
                 } ?: true
         }
 
     override suspend fun enableDirectMessages(uuid: UUID) =
         newSuspendedTransaction(Dispatchers.IO) {
-            DirectMessageSettings.upsert {
+            DMSettingsTable.upsert {
                 it[userUuid] = uuid
                 it[directMessagesEnabled] = true
             }
@@ -48,7 +40,7 @@ class FallbackDirectMessageService : DirectMessageService, Services.Fallback {
 
     override suspend fun disableDirectMessages(uuid: UUID) =
         newSuspendedTransaction(Dispatchers.IO) {
-            DirectMessageSettings.upsert {
+            DMSettingsTable.upsert {
                 it[userUuid] = uuid
                 it[directMessagesEnabled] = false
             }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
@@ -27,7 +27,7 @@ class FallbackFunctionalityService : FunctionalityService, Services.Fallback {
     override suspend fun isEnabledForServer(server: ChatServer): Boolean = newSuspendedTransaction(
         Dispatchers.IO
     ) {
-        FunctionalityTable.select(FunctionalityTable.server eq server.internalName)
+        FunctionalityTable.selectAll().where(FunctionalityTable.server eq server.internalName)
             .firstOrNull()?.let {
                 it[FunctionalityTable.chatEnabled]
             } ?: true

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
@@ -1,0 +1,98 @@
+package dev.slne.surf.chat.fallback.service
+
+import com.google.auto.service.AutoService
+import dev.slne.surf.chat.api.server.ChatServer
+import dev.slne.surf.chat.core.service.FunctionalityService
+import dev.slne.surf.chat.fallback.table.FunctionalityTable
+import dev.slne.surf.surfapi.core.api.util.toObjectSet
+import it.unimi.dsi.fastutil.objects.ObjectSet
+import kotlinx.coroutines.Dispatchers
+import net.kyori.adventure.util.Services
+import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.upsert
+
+@AutoService(FunctionalityService::class)
+class FallbackFunctionalityService : FunctionalityService, Services.Fallback {
+    var localChatEnabled = true
+    override fun createTable() {
+        transaction {
+            SchemaUtils.create(FunctionalityTable)
+        }
+    }
+
+    override suspend fun isEnabledForServer(server: ChatServer): Boolean = newSuspendedTransaction(
+        Dispatchers.IO
+    ) {
+        FunctionalityTable.select(FunctionalityTable.server eq server.internalName)
+            .firstOrNull()?.let {
+                it[FunctionalityTable.chatEnabled]
+            } ?: true
+    }
+
+    override suspend fun getAllServers(): ObjectSet<ChatServer> = newSuspendedTransaction(
+        Dispatchers.IO
+    ) {
+        FunctionalityTable.selectAll().map {
+            ChatServer.of(it[FunctionalityTable.server])
+        }.toObjectSet()
+    }
+
+    override suspend fun getAllEnabledServers(): ObjectSet<ChatServer> = newSuspendedTransaction(
+        Dispatchers.IO
+    ) {
+        FunctionalityTable.selectAll().where(FunctionalityTable.chatEnabled eq true).map {
+            ChatServer.of(it[FunctionalityTable.server])
+        }.toObjectSet()
+    }
+
+    override suspend fun getAllDisabledServers(): ObjectSet<ChatServer> = newSuspendedTransaction(
+        Dispatchers.IO
+    ) {
+        FunctionalityTable.selectAll().where(FunctionalityTable.chatEnabled eq false).map {
+            ChatServer.of(it[FunctionalityTable.server])
+        }.toObjectSet()
+    }
+
+    override suspend fun enableLocalChat(localServer: ChatServer) {
+        localChatEnabled = true
+
+        newSuspendedTransaction(Dispatchers.IO) {
+            FunctionalityTable.upsert {
+                it[server] = localServer.internalName
+                it[chatEnabled] = true
+            }
+        }
+    }
+
+    override suspend fun toggleLocalChat(localServer: ChatServer): Boolean {
+        localChatEnabled = !localChatEnabled
+
+        newSuspendedTransaction(Dispatchers.IO) {
+            FunctionalityTable.upsert {
+                it[server] = localServer.internalName
+                it[chatEnabled] = localChatEnabled
+            }
+        }
+
+        return localChatEnabled
+    }
+
+    override suspend fun disableLocalChat(localServer: ChatServer) {
+        localChatEnabled = false
+
+        newSuspendedTransaction(Dispatchers.IO) {
+            FunctionalityTable.upsert {
+                it[server] = localServer.internalName
+                it[chatEnabled] = false
+            }
+        }
+    }
+
+    override fun isLocalChatEnabled(): Boolean {
+        return localChatEnabled
+    }
+}

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
@@ -57,6 +57,13 @@ class FallbackFunctionalityService : FunctionalityService, Services.Fallback {
         }.toObjectSet()
     }
 
+    override suspend fun fetch(localServer: ChatServer) = newSuspendedTransaction(Dispatchers.IO) {
+        val result = FunctionalityTable.selectAll()
+            .where(FunctionalityTable.server eq localServer.internalName)
+            .firstOrNull()
+        localChatEnabled = result?.get(FunctionalityTable.chatEnabled) ?: true
+    }
+
     override suspend fun enableLocalChat(localServer: ChatServer) {
         localChatEnabled = true
 

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackNotificationService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackNotificationService.kt
@@ -2,11 +2,11 @@ package dev.slne.surf.chat.fallback.service
 
 import com.google.auto.service.AutoService
 import dev.slne.surf.chat.core.service.NotificationService
+import dev.slne.surf.chat.fallback.table.NotifySettingsTable
 import kotlinx.coroutines.Dispatchers
 import net.kyori.adventure.util.Services
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
@@ -15,31 +15,22 @@ import java.util.*
 
 @AutoService(NotificationService::class)
 class FallbackNotificationService : NotificationService, Services.Fallback {
-    object NotificationSettings : Table("chat_notifications") {
-        val userUuid =
-            varchar("user_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
-        val pingsEnabled = bool("pings_enabled").default(true)
-        val invitesEnabled = bool("invites_enabled").default(true)
-
-        override val primaryKey = PrimaryKey(userUuid)
-    }
-
     override fun createTable() {
         transaction {
-            SchemaUtils.create(NotificationSettings)
+            SchemaUtils.create(NotifySettingsTable)
         }
     }
 
     override suspend fun pingsEnabled(uuid: UUID) =
         newSuspendedTransaction(Dispatchers.IO) {
-            NotificationSettings.selectAll().where(NotificationSettings.userUuid eq uuid)
+            NotifySettingsTable.selectAll().where(NotifySettingsTable.userUuid eq uuid)
                 .firstOrNull()?.let {
-                    it[NotificationSettings.pingsEnabled]
+                    it[NotifySettingsTable.pingsEnabled]
                 } ?: true
         }
 
     override suspend fun enablePings(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotificationSettings.upsert {
+        NotifySettingsTable.upsert {
             it[userUuid] = uuid
             it[pingsEnabled] = true
         }
@@ -47,7 +38,7 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
     }
 
     override suspend fun disablePings(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotificationSettings.upsert {
+        NotifySettingsTable.upsert {
             it[userUuid] = uuid
             it[pingsEnabled] = false
         }
@@ -56,14 +47,14 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
     }
 
     override suspend fun invitesEnabled(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotificationSettings.selectAll().where(NotificationSettings.userUuid eq uuid)
+        NotifySettingsTable.selectAll().where(NotifySettingsTable.userUuid eq uuid)
             .firstOrNull()?.let {
-                it[NotificationSettings.invitesEnabled]
+                it[NotifySettingsTable.invitesEnabled]
             } ?: true
     }
 
     override suspend fun enableInvites(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotificationSettings.upsert {
+        NotifySettingsTable.upsert {
             it[userUuid] = uuid
             it[invitesEnabled] = true
         }
@@ -72,7 +63,7 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
 
 
     override suspend fun disableInvites(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotificationSettings.upsert {
+        NotifySettingsTable.upsert {
             it[userUuid] = uuid
             it[invitesEnabled] = false
         }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/DMSettingsTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/DMSettingsTable.kt
@@ -1,0 +1,12 @@
+package dev.slne.surf.chat.fallback.table
+
+import org.jetbrains.exposed.sql.Table
+import java.util.*
+
+object DMSettingsTable : Table("chat_settings_dm") {
+    val userUuid =
+        varchar("user_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+    val directMessagesEnabled = bool("direct_messages_enabled").default(true)
+
+    override val primaryKey = PrimaryKey(userUuid)
+}

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/DenylistTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/DenylistTable.kt
@@ -1,0 +1,13 @@
+package dev.slne.surf.chat.fallback.table
+
+import org.jetbrains.exposed.sql.Table
+
+object DenylistTable : Table("chat_denylist") {
+    val index = integer("index").autoIncrement().uniqueIndex()
+    val word = varchar("word", 255).uniqueIndex()
+    val reason = text("reason")
+    val addedBy = varchar("added_by", 16)
+    val addedAt = long("added_at")
+
+    override val primaryKey = PrimaryKey(index)
+}

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/FunctionalityTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/FunctionalityTable.kt
@@ -3,9 +3,8 @@ package dev.slne.surf.chat.fallback.table
 import org.jetbrains.exposed.sql.Table
 
 object FunctionalityTable : Table("chat_functionality") {
-    val index = integer("id").autoIncrement()
     val server = varchar("server", 256)
     val chatEnabled = bool("chat_enabled").default(true)
 
-    override val primaryKey = PrimaryKey(index)
+    override val primaryKey = PrimaryKey(server)
 }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/FunctionalityTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/FunctionalityTable.kt
@@ -6,4 +6,6 @@ object FunctionalityTable : Table("chat_functionality") {
     val index = integer("id").autoIncrement()
     val server = varchar("server", 256)
     val chatEnabled = bool("chat_enabled").default(true)
+
+    override val primaryKey = PrimaryKey(index)
 }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/FunctionalityTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/FunctionalityTable.kt
@@ -1,0 +1,9 @@
+package dev.slne.surf.chat.fallback.table
+
+import org.jetbrains.exposed.sql.Table
+
+object FunctionalityTable : Table("chat_functionality") {
+    val index = integer("id").autoIncrement()
+    val server = varchar("server", 256)
+    val chatEnabled = bool("chat_enabled").default(true)
+}

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/HistoryTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/HistoryTable.kt
@@ -1,0 +1,24 @@
+package dev.slne.surf.chat.fallback.table
+
+import dev.slne.surf.chat.api.message.MessageType
+import dev.slne.surf.chat.api.server.ChatServer
+import org.jetbrains.exposed.sql.Table
+import java.util.*
+
+object HistoryTable : Table("chat_history") {
+    val messageUuid =
+        varchar("message_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+    val senderUuid =
+        varchar("sender_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+    val receiverUuid =
+        varchar("receiver_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+            .nullable()
+    val message = text("message")
+    val sentAt = long("sent_at")
+    val type = text("type").transform({ MessageType.valueOf(it) }, { it.name })
+    val server = text("server").transform({ ChatServer.of(it) }, { it.internalName })
+    val channel = text("channel_name").nullable()
+    val deletedBy = text("deleted_by").nullable()
+
+    override val primaryKey = PrimaryKey(messageUuid)
+}

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/IgnoreListTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/IgnoreListTable.kt
@@ -1,0 +1,16 @@
+package dev.slne.surf.chat.fallback.table
+
+import org.jetbrains.exposed.sql.Table
+import java.util.*
+
+object IgnoreListTable : Table("chat_ignorelist") {
+    val userUuid =
+        varchar("user_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+    val userName = varchar("user_name", 16).default("Error")
+    val targetUuid =
+        varchar("target_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+    val targetName = varchar("target_name", 16).default("Error")
+    val createdAt = long("created_at")
+
+    override val primaryKey = PrimaryKey(userUuid, targetUuid)
+}

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/NotifySettingsTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/NotifySettingsTable.kt
@@ -1,0 +1,13 @@
+package dev.slne.surf.chat.fallback.table
+
+import org.jetbrains.exposed.sql.Table
+import java.util.*
+
+object NotifySettingsTable : Table("chat_settings_notify") {
+    val userUuid =
+        varchar("user_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+    val pingsEnabled = bool("pings_enabled").default(true)
+    val invitesEnabled = bool("invites_enabled").default(true)
+
+    override val primaryKey = PrimaryKey(userUuid)
+}

--- a/surf-chat-velocity/build.gradle.kts
+++ b/surf-chat-velocity/build.gradle.kts
@@ -7,7 +7,6 @@ velocityPluginFile {
     main = "dev.slne.surf.chat.velocity.VelocityMain"
     name = "SurfChatVelocity"
     authors = listOf("red")
-    description = "SurfChat Velocity Plugin"
     version = "${project.version}"
 }
 

--- a/surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/handler/ServerRequestHandler.kt
+++ b/surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/handler/ServerRequestHandler.kt
@@ -27,6 +27,7 @@ class ServerRequestHandler {
         if (event.source !is ServerConnection) {
             return
         }
+
         val connection = event.source as ServerConnection
         connection.sendPluginMessage(
             channelServerResponse,


### PR DESCRIPTION
This pull request introduces a significant refactor to how chat servers are represented and handled throughout the codebase. The main change is the replacement of the `server` field from a simple `String` to a new `ChatServer` interface, which offers a structured, type-safe way to represent server information. Additionally, several new commands and configuration reloads are introduced, and some code cleanup is performed.

Key changes include:

**Chat Server Refactor:**

* Replaced all usages of the `server` field (in `HistoryEntry`, `HistoryFilter`, and related APIs) from `String` to the new `ChatServer` interface, providing both a user-facing name and an internal identifier. Default and factory methods are added to `ChatServer` for easier instantiation and handling of unspecified servers. [[1]](diffhunk://#diff-cbe75e7c9d8191a42d8996a1b564d096eab800a3bf7d749899a8d761f294ba54L37-R38) [[2]](diffhunk://#diff-40383fe5cd0a4012e1ed79e0462be3b3a2834ab7a3a1676333870ea172aa4153L26-R27) [[3]](diffhunk://#diff-40383fe5cd0a4012e1ed79e0462be3b3a2834ab7a3a1676333870ea172aa4153L53-R54) [[4]](diffhunk://#diff-005da3d93df03b4c7b1376ccb0e2879d74fb659897827cb41a57931f0bf38e23R18-R40)
* Updated relevant imports and usages throughout the codebase to use `ChatServer` instead of `String`. This includes changes in command handling, filter parsing, and message creation. [[1]](diffhunk://#diff-81ec67249dbae3387f127c8c67fafdd6432b35d175b11d40195d292456faf306R5-L16) [[2]](diffhunk://#diff-90b8842f56523c85b0cdc711043b38313f4f593add6399ba1fe9aafe024b32b0R9) [[3]](diffhunk://#diff-bb9ffee18aab11445333141a119462de38d07cb020f3b1086fc77dd8c988abbeR13) [[4]](diffhunk://#diff-bb9ffee18aab11445333141a119462de38d07cb020f3b1086fc77dd8c988abbeL192-R195) [[5]](diffhunk://#diff-90b8842f56523c85b0cdc711043b38313f4f593add6399ba1fe9aafe024b32b0L37-R40)

**Command and Argument Improvements:**

* Added a new `ChatServerArgument` for commands, allowing commands to accept and process `ChatServer` objects directly.
* Updated the `surfchat lookup` command to display the server name properly and parse server arguments as `ChatServer` objects. [[1]](diffhunk://#diff-bb9ffee18aab11445333141a119462de38d07cb020f3b1086fc77dd8c988abbeL132-R133) [[2]](diffhunk://#diff-bb9ffee18aab11445333141a119462de38d07cb020f3b1086fc77dd8c988abbeL192-R195)

**Configuration and Plugin Enhancements:**

* Introduced new configuration providers (`ChatServerProviderConfig`, `AutoDisablingConfigProvider`) and ensured they are reloaded correctly in the reload command. The plugin now instantiates its `ChatServer` based on config values. [[1]](diffhunk://#diff-81ec67249dbae3387f127c8c67fafdd6432b35d175b11d40195d292456faf306R40-R46) [[2]](diffhunk://#diff-74afe7d7442510d9d9e40377b08a52752c17858650258841ea527f4778022464L14-R22)
* Ensured `functionalityService` is fetched with the correct server context during plugin load.

**New Functionality Management Commands:**

* Added a new `functionality` command group under `/surfchat`, including subcommands for changing, listing, and checking the status of chat functionality per server. [[1]](diffhunk://#diff-f87eca462454d17f633b25bc231ca7e49efad3cb76321fa15af9aca04138ad2cR15) [[2]](diffhunk://#diff-512cb51616b5205ffb8f28cb0a897b4208a41cc3294bb3af8324f6f2f0a7d1c7R1-R13) [[3]](diffhunk://#diff-4e7209b18cea518a27943f6c45478786231d91180da24730aff270f31bedba92R1-R59)

**Code Cleanup and Minor Fixes:**

* Removed unused fields and imports, such as the old `serverName` variable and unnecessary `Optional` usage.
* Updated invite component methods for clarity and maintainability. [[1]](diffhunk://#diff-94871d48d98222186c39facabdb9dc3f2409422c846111513d276b1ccd4a6c62L13-R14) [[2]](diffhunk://#diff-94871d48d98222186c39facabdb9dc3f2409422c846111513d276b1ccd4a6c62L90-R92)
* Removed redundant Gradle shadowJar configuration.

These changes collectively improve type safety, maintainability, and extensibility of the chat server handling in the codebase, while also introducing new administrative commands and configuration options.

resolves #71 