### PR TITLE
feat: integrate metrics tracking for performance monitoring

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
@@ -10,9 +10,12 @@ import dev.slne.surf.chat.bukkit.config.ConnectionMessageConfigProvider
 import dev.slne.surf.chat.core.service.databaseService
 import dev.slne.surf.chat.core.service.denylistService
 import dev.slne.surf.chat.core.service.functionalityService
+import dev.slne.surf.surfapi.bukkit.api.metrics.Metrics
 import org.bukkit.plugin.java.JavaPlugin
 
 val plugin get() = JavaPlugin.getPlugin(BukkitMain::class.java)
+
+lateinit var metrics: Metrics
 
 class BukkitMain : SuspendingJavaPlugin() {
     override fun onLoad() {
@@ -29,10 +32,16 @@ class BukkitMain : SuspendingJavaPlugin() {
             denylistService.fetch()
             functionalityService.fetch(server)
         }
+
+        metrics = Metrics(this, 27048)
     }
 
     override fun onDisable() {
         databaseService.closeConnection()
+
+        if (::metrics.isInitialized) {
+            metrics.shutdown()
+        }
     }
 
     val connectionMessageConfig = ConnectionMessageConfigProvider()


### PR DESCRIPTION
This pull request introduces integration with the `Metrics` system to the `BukkitMain` plugin. The main focus is on initializing metrics collection when the plugin is loaded and ensuring proper shutdown of the metrics system when the plugin is disabled.

**Metrics Integration:**

* Imported the `Metrics` class and added a global `metrics` variable for use within the plugin (`BukkitMain.kt`).
* Initialized the `metrics` instance in the `onLoad()` method and ensured it is properly shut down in the `onDisable()` method to manage resource usage and avoid memory leaks (`BukkitMain.kt`).