### PR TITLE
Feat/add cloud punishments

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.8-4.0.1-SNAPSHOT
+version=1.21.8-4.0.2-SNAPSHOT

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,9 @@
 [versions]
 playerholder-api = "2.11.6"
 surf-database = "2.0.4-SNAPSHOT"
+surf-cloud-api-common = "1.21.8-1.0.0-SNAPSHOT"
 
 [libraries]
 playerholder-api = { module = "me.clip:placeholderapi", version.ref = "playerholder-api" }
 surf-database = { module = "dev.slne.surf:surf-database", version.ref = "surf-database" }
+surf-cloud-api-common = { module = "dev.slne.surf.cloud:surf-cloud-api-common", version.ref = "surf-cloud-api-common" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,7 @@
 [versions]
 playerholder-api = "2.11.6"
 surf-database = "2.0.4-SNAPSHOT"
-surf-cloud-api-common = "1.21.8-1.0.0-SNAPSHOT"
 
 [libraries]
 playerholder-api = { module = "me.clip:placeholderapi", version.ref = "playerholder-api" }
 surf-database = { module = "dev.slne.surf:surf-database", version.ref = "surf-database" }
-surf-cloud-api-common = { module = "dev.slne.surf.cloud:surf-cloud-api-common", version.ref = "surf-cloud-api-common" }

--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/DenylistAction.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/DenylistAction.kt
@@ -1,7 +1,6 @@
 package dev.slne.surf.chat.api
 
 import dev.slne.surf.chat.api.entry.DenylistActionType
-import net.kyori.adventure.text.Component
 
 /**
  * Represents an action to be applied to a user in the denylist system.
@@ -28,7 +27,7 @@ interface DenylistAction {
      * This reason is displayed as a component and provides contextual
      * information about the action being performed.
      */
-    val reason: Component
+    val reason: String
 
     /**
      * The duration of the denylist action, represented in milliseconds.

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionAddCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionAddCommand.kt
@@ -9,20 +9,18 @@ import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.core.entry.DenylistActionImpl
 import dev.slne.surf.chat.core.service.denylistActionService
-import dev.slne.surf.surfapi.bukkit.api.command.args.miniMessageArgument
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
-import net.kyori.adventure.text.Component
 
 fun CommandAPICommand.denylistActionAddCommand() = subcommand("add") {
     withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_ACTION_ADD)
     stringArgument("name")
     denylistActionTypeArgument("type")
-    miniMessageArgument("reason")
     integerArgument("durationInMinutes", 0)
+    greedyStringArgument("reason")
     anyExecutor { executor, args ->
         val name: String by args
         val type: DenylistActionType by args
-        val reason: Component by args
+        val reason: String by args
         val durationInMinutes: Int by args
 
         if (denylistActionService.hasLocalAction(name)) {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionListCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionListCommand.kt
@@ -48,7 +48,7 @@ fun CommandAPICommand.denylistActionListCommand() = subcommand("list") {
                             variableKey("Grund")
                             spacer(":")
                             appendSpace()
-                            append(entry.reason)
+                            variableValue(entry.reason)
                         })
                     }
                 )

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistActionImpl.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistActionImpl.kt
@@ -2,7 +2,6 @@ package dev.slne.surf.chat.core.entry
 
 import dev.slne.surf.chat.api.DenylistAction
 import dev.slne.surf.chat.api.entry.DenylistActionType
-import net.kyori.adventure.text.Component
 
 /**
  * Implementation of the `DenylistAction` interface.
@@ -14,12 +13,12 @@ import net.kyori.adventure.text.Component
  *
  * @property name The unique name identifying the denylist action.
  * @property actionType Specifies the type of action, such as banning, muting, kicking, or warning.
- * @property reason The reason associated with this action, represented as a component for contextual information.
+ * @property reason The reason associated with this action, represented as a string for contextual information.
  * @property duration The duration of the denylist action in milliseconds.
  */
 data class DenylistActionImpl(
     override val name: String,
     override val actionType: DenylistActionType,
-    override val reason: Component,
+    override val reason: String,
     override val duration: Long
 ) : DenylistAction

--- a/surf-chat-fallback/build.gradle.kts
+++ b/surf-chat-fallback/build.gradle.kts
@@ -6,3 +6,7 @@ dependencies {
     api(project(":surf-chat-core"))
     api(libs.surf.database)
 }
+
+surfRawPaperApi {
+    withCloudCommon()
+}

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistActionService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistActionService.kt
@@ -9,6 +9,9 @@ import dev.slne.surf.chat.core.service.DenylistActionService
 import dev.slne.surf.chat.core.service.historyService
 import dev.slne.surf.chat.fallback.entity.DenylistActionEntity
 import dev.slne.surf.chat.fallback.table.DenylistActionsTable
+import dev.slne.surf.chat.fallback.util.toOfflineCloudPlayer
+import dev.slne.surf.cloud.api.common.player.punishment.type.PunishType
+import dev.slne.surf.surfapi.core.api.util.logger
 import dev.slne.surf.surfapi.core.api.util.mutableObjectSetOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -16,9 +19,12 @@ import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.util.Services
 import org.bukkit.Bukkit
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit
 import java.util.*
 import kotlin.time.Duration.Companion.seconds
 
+@Suppress("MISSING_DEPENDENCY_SUPERCLASS_IN_TYPE_ARGUMENT")
 @AutoService(DenylistActionService::class)
 class FallbackDenylistActionService : DenylistActionService, Services.Fallback {
     val localActions = mutableObjectSetOf<DenylistAction>()
@@ -67,26 +73,62 @@ class FallbackDenylistActionService : DenylistActionService, Services.Fallback {
         message: SignedMessage,
         sender: User
     ) {
-        when (entry.action.actionType) {
-            DenylistActionType.BAN -> {
-                println("Banning ${sender.name}")
-            }
+        if (isCloud()) {
+            val cloudPlayer = sender.toOfflineCloudPlayer()
+            val punishManager = cloudPlayer.punishmentManager
 
-            DenylistActionType.KICK -> {
-                println("Kicking ${sender.name}")
-            }
+            when (entry.action.actionType) {
+                DenylistActionType.BAN -> {
+                    punishManager.punish(
+                        PunishType.BAN.Expirable(
+                            ZonedDateTime.now().plus(
+                                entry.action.duration,
+                                ChronoUnit.MILLIS
+                            )
+                        )
+                            .withNote("Punished by Arty Support (surf-chat) for: ${entry.word} (messageUid: $messageUuid)"),
+                        entry.action.reason
+                    )
+                }
 
-            DenylistActionType.MUTE -> {
-                println("Muting ${sender.name}")
-            }
+                DenylistActionType.KICK -> {
+                    punishManager.punish(
+                        PunishType.KICK
+                            .withNote("Punished by Arty Support (surf-chat) for: ${entry.word} (messageUid: $messageUuid)"),
+                        entry.action.reason
+                    )
+                }
 
-            DenylistActionType.WARN -> {
-                println("Warning ${sender.name}")
+                DenylistActionType.MUTE -> {
+                    punishManager.punish(
+                        PunishType.MUTE.Expirable(
+                            ZonedDateTime.now().plus(
+                                entry.action.duration,
+                                ChronoUnit.MILLIS
+                            )
+                        )
+                            .withNote("Punished by Arty Support (surf-chat) for: ${entry.word} (messageUid: $messageUuid)"),
+                        entry.action.reason
+                    )
+                }
+
+                DenylistActionType.WARN -> {
+                    punishManager.punish(
+                        PunishType.WARN
+                            .withNote("Punished by Arty Support (surf-chat) for: ${entry.word} (messageUid: $messageUuid)"),
+                        entry.action.reason
+                    )
+                }
             }
+        } else {
+            logger().atSevere()
+                .log("Unable to establish Cloud connection. Punishment actions for ${sender.name}: ${entry.word} / ${entry.action.actionType} will be ignored.")
         }
 
         delay(3.seconds)
         Bukkit.getServer().deleteMessage(message)
         historyService.markDeleted(messageUuid, "Arty Support (BLOCKED: ${entry.word})")
     }
+
+    private fun isCloud() = Bukkit.getPluginManager().isPluginEnabled("surf-cloud-bukkit")
 }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
@@ -99,7 +99,5 @@ class FallbackFunctionalityService : FunctionalityService, Services.Fallback {
         }
     }
 
-    override fun isLocalChatEnabled(): Boolean {
-        return localChatEnabled
-    }
+    override fun isLocalChatEnabled() = localChatEnabled
 }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/DenylistActionsTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/DenylistActionsTable.kt
@@ -1,15 +1,12 @@
 package dev.slne.surf.chat.fallback.table
 
 import dev.slne.surf.chat.api.entry.DenylistActionType
-import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer
 import org.jetbrains.exposed.dao.id.IntIdTable
 
 object DenylistActionsTable : IntIdTable("chat_denylist_actions") {
     var name = varchar("name", 64).uniqueIndex()
     var actionType =
         varchar("action_type", 16).transform({ DenylistActionType.valueOf(it) }, { it.toString() })
-    var reason = largeText("reason").transform(
-        { GsonComponentSerializer.gson().deserialize(it) },
-        { GsonComponentSerializer.gson().serialize(it) })
+    var reason = largeText("reason")
     var duration = long("duration")
 }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/util/fallback-util.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/util/fallback-util.kt
@@ -1,6 +1,9 @@
 package dev.slne.surf.chat.fallback.util
 
+import dev.slne.surf.chat.api.entity.User
 import dev.slne.surf.chat.core.Constants
+import dev.slne.surf.cloud.api.common.player.CloudPlayer
+import dev.slne.surf.cloud.api.common.player.OfflineCloudPlayer
 import dev.slne.surf.surfapi.core.api.font.toSmallCaps
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
@@ -16,3 +19,6 @@ fun SurfComponentBuilder.appendBotIcon() = append {
     darkSpacer("]")
     appendSpace()
 }
+
+fun User.toCloudPlayer() = CloudPlayer[this.uuid]
+fun User.toOfflineCloudPlayer() = OfflineCloudPlayer[this.uuid]


### PR DESCRIPTION
This pull request refactors the denylist action system to simplify how reasons for actions are handled and integrates cloud-based punishment management. The main change is switching the `reason` field from a complex `Component` type to a simple `String`, making it easier to store, retrieve, and display reasons. Additionally, the fallback service now supports cloud-based punishments when available, and some minor improvements and dependency updates are included.

**Denylist Action Reason Refactor:**
* Changed the `reason` property in the `DenylistAction` interface and its implementation from `Component` to `String`, simplifying its handling throughout the codebase (`DenylistAction.kt`, `DenylistActionImpl.kt`, `DenylistActionsTable.kt`, command files). [[1]](diffhunk://#diff-c01ce200f84350623746532fafe21d999e36acba58c7c77f39d52d7451e956a3L31-R30) [[2]](diffhunk://#diff-3777cb21c2eb5de6f08981807c637d2da2f444aa027baf342ad4a44b3b8cc33dL17-R22) [[3]](diffhunk://#diff-a77f4d0b0bf372405bea1fe6771fb683b99c14b0624a1f89caaebceff67bfe01L4-R10) [[4]](diffhunk://#diff-60adeee1878d3e840d6aac9a27d659b9e6507a1232ab2a35c787e4c94fcc4f55L12-R23) [[5]](diffhunk://#diff-8e194e0697d37bed5a67ee66d9aa9a300fda06ae2ca13818a617bc6c05a214b0L51-R51)

**Cloud Punishment Integration:**
* Updated `FallbackDenylistActionService` to use cloud punishment APIs when the cloud plugin is enabled, applying bans, kicks, mutes, and warnings via the cloud system and logging a severe warning if cloud is unavailable. Added helper methods for converting users to cloud player types. [[1]](diffhunk://#diff-8e49b6301fedecf035b7e567d1bd711a0752ca5811004cf3624e15a89b31d3a1R76-R133) [[2]](diffhunk://#diff-9a1482fd2c881f8fdb05d5b61dbe7232dcd980f1cdd0a8eb026cc8d7f4b1e87bR22-R24)

**Dependency and Version Updates:**
* Added `surf-cloud-api-common` as a dependency, updated `gradle.properties` and `libs.versions.toml` to reflect the new version and dependency. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L4-R4) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR4-R9) [[3]](diffhunk://#diff-6fb4cf564105863cfb869a342b0c251f1e7630d837506422524acab5f2b3cf30R9-R12)

**Minor Code Improvements:**
* Simplified method syntax in `FallbackFunctionalityService` for `isLocalChatEnabled`.

**Cleanup of Imports:**
* Removed unused imports related to `Component` and serializers in files affected by the reason refactor. [[1]](diffhunk://#diff-c01ce200f84350623746532fafe21d999e36acba58c7c77f39d52d7451e956a3L4) [[2]](diffhunk://#diff-3777cb21c2eb5de6f08981807c637d2da2f444aa027baf342ad4a44b3b8cc33dL5) [[3]](diffhunk://#diff-a77f4d0b0bf372405bea1fe6771fb683b99c14b0624a1f89caaebceff67bfe01L4-R10) [[4]](diffhunk://#diff-60adeee1878d3e840d6aac9a27d659b9e6507a1232ab2a35c787e4c94fcc4f55L12-R23) [[5]](diffhunk://#diff-3777cb21c2eb5de6f08981807c637d2da2f444aa027baf342ad4a44b3b8cc33dL17-R22)

Let me know if you want a walkthrough of how the cloud integration works or more details about the reason type refactor!