### PR TITLE
Fix/rework team permissions

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/spy/DirectMessageSpyCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/spy/DirectMessageSpyCommand.kt
@@ -26,7 +26,7 @@ fun directMessageSpyCommand() = commandAPICommand("spy") {
             return@playerExecutor
         }
 
-        if (target.hasPermission(SurfChatPermissionRegistry.TEAM_ACCESS)) {
+        if (target.hasPermission(SurfChatPermissionRegistry.TEAM_BYPASS_SPY)) {
             player.sendText {
                 appendPrefix()
                 error("Du kannst keine Teammitglieder spionieren!")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityChangeCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/functionality/FunctionalityChangeCommand.kt
@@ -27,7 +27,8 @@ fun CommandAPICommand.functionalityChangeCommand() = subcommand("change") {
                 }
 
                 Bukkit.getOnlinePlayers()
-                    .filter { it.hasPermission(SurfChatPermissionRegistry.TEAM_ACCESS) }.forEach {
+                    .filter { it.hasPermission(SurfChatPermissionRegistry.TEAM_NOTIFY_FUNCTIONALITY) }
+                    .forEach {
                         it.sendText {
                             appendPrefix()
                             variableValue(player.name)
@@ -44,7 +45,8 @@ fun CommandAPICommand.functionalityChangeCommand() = subcommand("change") {
                 }
 
                 Bukkit.getOnlinePlayers()
-                    .filter { it.hasPermission(SurfChatPermissionRegistry.TEAM_ACCESS) }.forEach {
+                    .filter { it.hasPermission(SurfChatPermissionRegistry.TEAM_NOTIFY_FUNCTIONALITY) }
+                    .forEach {
                         it.sendText {
                             appendPrefix()
                             variableValue(player.name)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/message/MessageValidatorImpl.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/message/MessageValidatorImpl.kt
@@ -39,7 +39,7 @@ class MessageValidatorImpl {
         private val messageTimestamps = mutableObject2ObjectMapOf<UUID, ObjectList<Long>>()
 
         override fun validate(user: User): MessageValidationResult {
-            if (user.hasPermission(SurfChatPermissionRegistry.FILTER_BYPASS)) {
+            if (user.hasPermission(SurfChatPermissionRegistry.TEAM_BYPASS_FILTER)) {
                 return MessageValidationResult.Success()
             }
 
@@ -48,7 +48,7 @@ class MessageValidatorImpl {
             }
 
             if (!functionalityService.isLocalChatEnabled() && !user.hasPermission(
-                    SurfChatPermissionRegistry.TEAM_ACCESS
+                    SurfChatPermissionRegistry.TEAM_BYPASS_FUNCTIONALITY
                 )
             ) {
                 return MessageValidationResult.Failure(MessageValidationResult.MessageValidationError.ChatDisabled())

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
@@ -6,15 +6,16 @@ import dev.slne.surf.surfapi.bukkit.api.permission.PermissionRegistry
 object SurfChatPermissionRegistry : PermissionRegistry() {
     private const val PREFIX = "surf.chat"
     private const val PREFIX_COMMAND = "$PREFIX.command"
+    private const val PREFIX_TEAM = "$PREFIX.team"
 
     val AUTO_CHAT_DISABLING_BYPASS = create("$PREFIX.disabling.bypass")
 
     val TEAM_CHAT = create(Constants.PERMISSION_TEAMCHAT)
-    val TEAM_BYPASS_FILTER = create("$PREFIX.bypass.filter")
-    val TEAM_BYPASS_SPY = create("$PREFIX.bypass.spy")
-    val TEAM_BYPASS_FUNCTIONALITY = create("$PREFIX.bypass.functionality")
-    val TEAM_NOTIFY_FUNCTIONALITY = create("$PREFIX.notify.functionality")
-    val TEAM_NOTIFY_DELETION = create("$PREFIX.notify.deletion")
+    val TEAM_BYPASS_FILTER = create("$PREFIX_TEAM.bypass.filter")
+    val TEAM_BYPASS_SPY = create("$PREFIX_TEAM.bypass.spy")
+    val TEAM_BYPASS_FUNCTIONALITY = create("$PREFIX_TEAM.bypass.functionality")
+    val TEAM_NOTIFY_FUNCTIONALITY = create("$PREFIX_TEAM.notify.functionality")
+    val TEAM_NOTIFY_DELETION = create("$PREFIX_TEAM.notify.deletion")
 
     val COMMAND_SURFCHAT = create("$PREFIX_COMMAND.surfchat")
     val COMMAND_SURFCHAT_RELOAD = create("$PREFIX_COMMAND.surfchat.reload")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
@@ -7,9 +7,14 @@ object SurfChatPermissionRegistry : PermissionRegistry() {
     private const val PREFIX = "surf.chat"
     private const val PREFIX_COMMAND = "$PREFIX.command"
 
-    val FILTER_BYPASS = create("$PREFIX.filter.bypass")
-    val TEAM_ACCESS = create(Constants.TEAM_PERMISSION)
     val AUTO_CHAT_DISABLING_BYPASS = create("$PREFIX.disabling.bypass")
+
+    val TEAM_CHAT = create(Constants.PERMISSION_TEAMCHAT)
+    val TEAM_BYPASS_FILTER = create("$PREFIX.bypass.filter")
+    val TEAM_BYPASS_SPY = create("$PREFIX.bypass.spy")
+    val TEAM_BYPASS_FUNCTIONALITY = create("$PREFIX.bypass.functionality")
+    val TEAM_NOTIFY_FUNCTIONALITY = create("$PREFIX.notify.functionality")
+    val TEAM_NOTIFY_DELETION = create("$PREFIX.notify.deletion")
 
     val COMMAND_SURFCHAT = create("$PREFIX_COMMAND.surfchat")
     val COMMAND_SURFCHAT_RELOAD = create("$PREFIX_COMMAND.surfchat.reload")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
@@ -35,7 +35,7 @@ fun SurfComponentBuilder.appendDelete(messageData: MessageData) = append(buildTe
 
         Bukkit.getServer().deleteMessage(signature)
         Bukkit.getOnlinePlayers()
-            .filter { online -> online.hasPermission(SurfChatPermissionRegistry.TEAM_ACCESS) }
+            .filter { online -> online.hasPermission(SurfChatPermissionRegistry.TEAM_NOTIFY_DELETION) }
             .forEach { online ->
                 online.sendText {
                     appendPrefix()

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/util.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/util.kt
@@ -40,7 +40,7 @@ fun Cancellable.cancel() {
 }
 
 fun sendTeamMessage(message: SurfComponentBuilder.() -> Unit) =
-    Bukkit.getOnlinePlayers().filter { it.hasPermission(Constants.TEAM_PERMISSION) }
+    Bukkit.getOnlinePlayers().filter { it.hasPermission(Constants.PERMISSION_TEAMCHAT) }
         .forEach { it.sendText(message) }
 
 fun Component.plainText(): String = PlainTextComponentSerializer.plainText().serialize(this)

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/Constants.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/Constants.kt
@@ -14,7 +14,7 @@ object Constants {
      * checked before sending messages to a subset of players to ensure they
      * possess the appropriate access rights.
      */
-    const val TEAM_PERMISSION = "surf.chat.team"
+    const val PERMISSION_TEAMCHAT = "surf.chat.teamchat"
 
     /**
      * Represents the channel identifier for team chat communication within the Surf Chat system.

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/util/fallback-util.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/util/fallback-util.kt
@@ -10,7 +10,7 @@ import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 import org.bukkit.Bukkit
 
 fun sendTeamMessage(message: SurfComponentBuilder.() -> Unit) =
-    Bukkit.getOnlinePlayers().filter { it.hasPermission(Constants.TEAM_PERMISSION) }
+    Bukkit.getOnlinePlayers().filter { it.hasPermission(Constants.PERMISSION_TEAMCHAT) }
         .forEach { it.sendText(message) }
 
 fun SurfComponentBuilder.appendBotIcon() = append {

--- a/surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/handler/TeamchatHandler.kt
+++ b/surf-chat-velocity/src/main/kotlin/dev/slne/surf/chat/velocity/handler/TeamchatHandler.kt
@@ -25,7 +25,7 @@ class TeamchatHandler {
             DataInputStream(byteStream).use { input ->
                 val message = GsonComponentSerializer.gson().deserialize(input.readUTF())
                 plugin.proxy.allPlayers
-                    .filter { it.hasPermission(Constants.TEAM_PERMISSION) }
+                    .filter { it.hasPermission(Constants.PERMISSION_TEAMCHAT) }
                     .forEach { it.sendText { append(message) } }
             }
         }


### PR DESCRIPTION
This pull request updates the permission system for team-related chat features, introducing more granular and descriptive permission constants and refactoring their usage across the codebase. The changes replace the previous broad `TEAM_PERMISSION` and related permissions with new, more specific permissions, improving maintainability and clarity in access control for team chat functionalities.

**Permission system refactoring:**

* Replaced `TEAM_PERMISSION` with `PERMISSION_TEAMCHAT` in the `Constants` object and updated all references to use the new constant for team chat access. [[1]](diffhunk://#diff-f7cc585a6716b4818d7eee5c83ad5ee4a0bb35946bc3c578d1179b476efe9b0dL17-R17) [[2]](diffhunk://#diff-6ea47a662c190d40fd3c2df7a12d63597059ac994a547165d5575048db9eaea2L43-R43) [[3]](diffhunk://#diff-9a1482fd2c881f8fdb05d5b61dbe7232dcd980f1cdd0a8eb026cc8d7f4b1e87bL13-R13) [[4]](diffhunk://#diff-5519acf6d83630c58aa64e0afedf17d97b347a08566479a842396171a83a10ddL28-R28)
* Removed `FILTER_BYPASS` and `TEAM_ACCESS` from `SurfChatPermissionRegistry`; added new granular permissions: `TEAM_CHAT`, `TEAM_BYPASS_FILTER`, `TEAM_BYPASS_SPY`, `TEAM_BYPASS_FUNCTIONALITY`, `TEAM_NOTIFY_FUNCTIONALITY`, and `TEAM_NOTIFY_DELETION`.

**Usage updates for new permissions:**

* Updated message validation logic to use `TEAM_BYPASS_FILTER` and `TEAM_BYPASS_FUNCTIONALITY` instead of the old permissions, ensuring correct bypass behavior for team members. [[1]](diffhunk://#diff-728e3fd4808e51e620851b2f4e1964898acb73e51cb0afd00eaf5066306674f7L42-R42) [[2]](diffhunk://#diff-728e3fd4808e51e620851b2f4e1964898acb73e51cb0afd00eaf5066306674f7L51-R51)
* Changed the team notification logic for functionality changes and deletions to use `TEAM_NOTIFY_FUNCTIONALITY` and `TEAM_NOTIFY_DELETION` respectively, providing more precise control over who receives these notifications. [[1]](diffhunk://#diff-4e7209b18cea518a27943f6c45478786231d91180da24730aff270f31bedba92L30-R31) [[2]](diffhunk://#diff-4e7209b18cea518a27943f6c45478786231d91180da24730aff270f31bedba92L47-R49) [[3]](diffhunk://#diff-280e1fba11baf357bdc318c363efc07f99cdbe1bd4c761c459fb776d7b1aa51aL38-R38)

**Command permission checks:**

* Updated the direct message spy command to use `TEAM_BYPASS_SPY` for permission checks, restricting spying on team members according to the new permission model.