### PR TITLE
Fix/update database stuff

### DIFF
--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/util.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/util.kt
@@ -69,7 +69,7 @@ fun Long.coloredComponent(good: Long = 200L, okay: Long = 1000L) =
     }
 
 fun TextColor.miniMessage() =
-    "<#${this.asHexString()}>"
+    "<${this.asHexString()}>"
 
 fun <C : BuildableComponent<C, B>, B : ComponentBuilder<C, B>> ComponentBuilder<C, B>.appendSpace(
     amount: Int,

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/entity/DMSettingsEntity.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/entity/DMSettingsEntity.kt
@@ -4,10 +4,21 @@ import dev.slne.surf.chat.fallback.table.DMSettingsTable
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
+import java.util.*
 
 class DMSettingsEntity(id: EntityID<Int>) : IntEntity(id) {
     companion object : IntEntityClass<DMSettingsEntity>(DMSettingsTable)
 
     var userUuid by DMSettingsTable.userUuid
     var directMessagesEnabled by DMSettingsTable.directMessagesEnabled
+
+    fun toDto() = DmSettingsDto(
+        userUuid = userUuid,
+        directMessagesEnabled = directMessagesEnabled
+    )
 }
+
+data class DmSettingsDto(
+    val userUuid: UUID,
+    val directMessagesEnabled: Boolean
+)

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDirectMessageService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDirectMessageService.kt
@@ -2,12 +2,11 @@ package dev.slne.surf.chat.fallback.service
 
 import com.google.auto.service.AutoService
 import dev.slne.surf.chat.core.service.DirectMessageService
+import dev.slne.surf.chat.fallback.entity.DMSettingsEntity
 import dev.slne.surf.chat.fallback.table.DMSettingsTable
 import kotlinx.coroutines.Dispatchers
 import net.kyori.adventure.util.Services
 import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.upsert
@@ -23,10 +22,8 @@ class FallbackDirectMessageService : DirectMessageService, Services.Fallback {
 
     override suspend fun directMessagesEnabled(uuid: UUID) =
         newSuspendedTransaction(Dispatchers.IO) {
-            DMSettingsTable.selectAll().where(DMSettingsTable.userUuid eq uuid)
-                .firstOrNull()?.let {
-                    it[DMSettingsTable.directMessagesEnabled]
-                } ?: true
+            DMSettingsEntity.find { DMSettingsTable.userUuid eq uuid }.firstOrNull()
+                ?.toDto()?.directMessagesEnabled ?: true
         }
 
     override suspend fun enableDirectMessages(uuid: UUID) =

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackNotificationService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackNotificationService.kt
@@ -2,12 +2,11 @@ package dev.slne.surf.chat.fallback.service
 
 import com.google.auto.service.AutoService
 import dev.slne.surf.chat.core.service.NotificationService
+import dev.slne.surf.chat.fallback.entity.NotifySettingsEntity
 import dev.slne.surf.chat.fallback.table.NotifySettingsTable
 import kotlinx.coroutines.Dispatchers
 import net.kyori.adventure.util.Services
 import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
-import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.upsert
@@ -23,10 +22,8 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
 
     override suspend fun pingsEnabled(uuid: UUID) =
         newSuspendedTransaction(Dispatchers.IO) {
-            NotifySettingsTable.selectAll().where(NotifySettingsTable.userUuid eq uuid)
-                .firstOrNull()?.let {
-                    it[NotifySettingsTable.pingsEnabled]
-                } ?: true
+            NotifySettingsEntity.find { NotifySettingsTable.userUuid eq uuid }
+                .firstOrNull()?.pingsEnabled ?: true
         }
 
     override suspend fun enablePings(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
@@ -47,10 +44,8 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
     }
 
     override suspend fun invitesEnabled(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotifySettingsTable.selectAll().where(NotifySettingsTable.userUuid eq uuid)
-            .firstOrNull()?.let {
-                it[NotifySettingsTable.invitesEnabled]
-            } ?: true
+        NotifySettingsEntity.find { NotifySettingsTable.userUuid eq uuid }
+            .firstOrNull()?.invitesEnabled ?: true
     }
 
     override suspend fun enableInvites(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {


### PR DESCRIPTION
This pull request refactors the fallback service layer to use Exposed DAO entities instead of direct table queries, improving code readability, maintainability, and consistency across the data access layer. It also introduces DTOs for better separation between persistence and business logic. Additionally, a minor formatting fix is made for MiniMessage color codes.

**Refactoring to Exposed DAO entities:**

* All fallback services (`FallbackDirectMessageService`, `FallbackFunctionalityService`, `FallbackHistoryService`, `FallbackIgnoreService`, `FallbackNotificationService`) now use Exposed DAO entities (e.g., `DMSettingsEntity`, `FunctionalityEntity`, `HistoryEntity`, `IgnoreListEntity`, `NotifySettingsEntity`) for data access and manipulation, replacing direct SQL/table operations. [[1]](diffhunk://#diff-ab49f21c8b0ddea0c111f5570b06fc8b28ccca3953726d08d28688eaa12d63b8L26-R26) [[2]](diffhunk://#diff-08269b17df9ab521566a9154a5a5499b2b0cb184471ac7c323c047d51cc5a7cfL30-R60) [[3]](diffhunk://#diff-bbcceaf5421c4fb3e002c5bf28b24efb3a2be599fc7660407e83fe60df374fc1L38-R51) [[4]](diffhunk://#diff-df2bdb8c2eba0539598aa3cb3dc83867047ae209489d1fbf5c811a2cdf2c8738L33-L71) [[5]](diffhunk://#diff-6412414fe3a34c1fbe57d655b2ea193e5a61de04fc200c881340c41d5fd11dacL26-R26) [[6]](diffhunk://#diff-6412414fe3a34c1fbe57d655b2ea193e5a61de04fc200c881340c41d5fd11dacL50-R48)

* Methods for enabling/disabling features, logging messages, ignoring/unignoring users, and fetching lists are updated to use entity methods and queries, improving encapsulation and reducing boilerplate. [[1]](diffhunk://#diff-ab49f21c8b0ddea0c111f5570b06fc8b28ccca3953726d08d28688eaa12d63b8L26-R26) [[2]](diffhunk://#diff-08269b17df9ab521566a9154a5a5499b2b0cb184471ac7c323c047d51cc5a7cfL30-R60) [[3]](diffhunk://#diff-bbcceaf5421c4fb3e002c5bf28b24efb3a2be599fc7660407e83fe60df374fc1L136-R141) [[4]](diffhunk://#diff-df2bdb8c2eba0539598aa3cb3dc83867047ae209489d1fbf5c811a2cdf2c8738L33-L71)

**Introduction of DTOs:**

* DTOs are introduced for entities such as `DmSettingsDto`, allowing for clean transfer of data between layers and making conversion explicit. [[1]](diffhunk://#diff-bd2527d98dc8db9c9a4daa4c088897be3fd6aef73d213f7639d29030285e0e36R7-R24) [[2]](diffhunk://#diff-df2bdb8c2eba0539598aa3cb3dc83867047ae209489d1fbf5c811a2cdf2c8738L33-L71)

**Code cleanup and imports:**

* Unused imports and direct SQL expressions are removed from service files, replaced by entity-based queries and operations for consistency. [[1]](diffhunk://#diff-ab49f21c8b0ddea0c111f5570b06fc8b28ccca3953726d08d28688eaa12d63b8R5-L10) [[2]](diffhunk://#diff-08269b17df9ab521566a9154a5a5499b2b0cb184471ac7c323c047d51cc5a7cfR6-L13) [[3]](diffhunk://#diff-bbcceaf5421c4fb3e002c5bf28b24efb3a2be599fc7660407e83fe60df374fc1R9) [[4]](diffhunk://#diff-bbcceaf5421c4fb3e002c5bf28b24efb3a2be599fc7660407e83fe60df374fc1L18-R25) [[5]](diffhunk://#diff-df2bdb8c2eba0539598aa3cb3dc83867047ae209489d1fbf5c811a2cdf2c8738L6-R13) [[6]](diffhunk://#diff-6412414fe3a34c1fbe57d655b2ea193e5a61de04fc200c881340c41d5fd11dacR5-L10)

**Formatting fix:**

* The `miniMessage` color formatting in `util.kt` is corrected to use the format `<hex>` instead of `<#hex>`, ensuring proper color code rendering.

**Overall, these changes modernize the fallback service implementation, reduce direct SQL usage, and improve maintainability.**