### PR TITLE
Fix/database inserting problems

### DIFF
--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
@@ -64,8 +64,7 @@ class FallbackFunctionalityService : FunctionalityService, Services.Fallback {
         localChatEnabled = true
 
         newSuspendedTransaction(Dispatchers.IO) {
-            FunctionalityTable.upsert {
-                it[server] = localServer.internalName
+            FunctionalityTable.upsert(where = { FunctionalityTable.server eq localServer.internalName }) {
                 it[chatEnabled] = true
             }
         }
@@ -76,7 +75,6 @@ class FallbackFunctionalityService : FunctionalityService, Services.Fallback {
 
         newSuspendedTransaction(Dispatchers.IO) {
             FunctionalityTable.upsert(where = { FunctionalityTable.server eq localServer.internalName }) {
-                it[server] = localServer.internalName
                 it[chatEnabled] = localChatEnabled
             }
         }
@@ -89,7 +87,6 @@ class FallbackFunctionalityService : FunctionalityService, Services.Fallback {
 
         newSuspendedTransaction(Dispatchers.IO) {
             FunctionalityTable.upsert(where = { FunctionalityTable.server eq localServer.internalName }) {
-                it[server] = localServer.internalName
                 it[chatEnabled] = false
             }
         }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackFunctionalityService.kt
@@ -75,7 +75,7 @@ class FallbackFunctionalityService : FunctionalityService, Services.Fallback {
         localChatEnabled = !localChatEnabled
 
         newSuspendedTransaction(Dispatchers.IO) {
-            FunctionalityTable.upsert {
+            FunctionalityTable.upsert(where = { FunctionalityTable.server eq localServer.internalName }) {
                 it[server] = localServer.internalName
                 it[chatEnabled] = localChatEnabled
             }
@@ -88,7 +88,7 @@ class FallbackFunctionalityService : FunctionalityService, Services.Fallback {
         localChatEnabled = false
 
         newSuspendedTransaction(Dispatchers.IO) {
-            FunctionalityTable.upsert {
+            FunctionalityTable.upsert(where = { FunctionalityTable.server eq localServer.internalName }) {
                 it[server] = localServer.internalName
                 it[chatEnabled] = false
             }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackNotificationService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackNotificationService.kt
@@ -27,15 +27,14 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
         }
 
     override suspend fun enablePings(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotifySettingsTable.upsert {
-            it[userUuid] = uuid
+        NotifySettingsTable.upsert(where = { NotifySettingsTable.userUuid eq uuid }) {
             it[pingsEnabled] = true
         }
         return@newSuspendedTransaction
     }
 
     override suspend fun disablePings(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotifySettingsTable.upsert {
+        NotifySettingsTable.upsert(where = { NotifySettingsTable.userUuid eq uuid }) {
             it[userUuid] = uuid
             it[pingsEnabled] = false
         }
@@ -49,7 +48,7 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
     }
 
     override suspend fun enableInvites(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotifySettingsTable.upsert {
+        NotifySettingsTable.upsert(where = { NotifySettingsTable.userUuid eq uuid }) {
             it[userUuid] = uuid
             it[invitesEnabled] = true
         }
@@ -58,7 +57,7 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
 
 
     override suspend fun disableInvites(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
-        NotifySettingsTable.upsert {
+        NotifySettingsTable.upsert(where = { NotifySettingsTable.userUuid eq uuid }) {
             it[userUuid] = uuid
             it[invitesEnabled] = false
         }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackNotificationService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackNotificationService.kt
@@ -35,7 +35,6 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
 
     override suspend fun disablePings(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
         NotifySettingsTable.upsert(where = { NotifySettingsTable.userUuid eq uuid }) {
-            it[userUuid] = uuid
             it[pingsEnabled] = false
         }
 
@@ -49,7 +48,6 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
 
     override suspend fun enableInvites(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
         NotifySettingsTable.upsert(where = { NotifySettingsTable.userUuid eq uuid }) {
-            it[userUuid] = uuid
             it[invitesEnabled] = true
         }
         return@newSuspendedTransaction
@@ -58,7 +56,6 @@ class FallbackNotificationService : NotificationService, Services.Fallback {
 
     override suspend fun disableInvites(uuid: UUID) = newSuspendedTransaction(Dispatchers.IO) {
         NotifySettingsTable.upsert(where = { NotifySettingsTable.userUuid eq uuid }) {
-            it[userUuid] = uuid
             it[invitesEnabled] = false
         }
         return@newSuspendedTransaction

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/DMSettingsTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/DMSettingsTable.kt
@@ -1,10 +1,8 @@
 package dev.slne.surf.chat.fallback.table
 
 import org.jetbrains.exposed.dao.id.IntIdTable
-import java.util.*
 
 object DMSettingsTable : IntIdTable("chat_settings_dm") {
-    val userUuid =
-        varchar("user_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+    val userUuid = uuid("user_uuid").uniqueIndex()
     val directMessagesEnabled = bool("direct_messages_enabled").default(true)
 }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/FunctionalityTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/FunctionalityTable.kt
@@ -3,6 +3,6 @@ package dev.slne.surf.chat.fallback.table
 import org.jetbrains.exposed.dao.id.IntIdTable
 
 object FunctionalityTable : IntIdTable("chat_functionality") {
-    val server = varchar("server", 256)
+    val server = varchar("server", 256).uniqueIndex()
     val chatEnabled = bool("chat_enabled").default(true)
 }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/HistoryTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/HistoryTable.kt
@@ -3,19 +3,14 @@ package dev.slne.surf.chat.fallback.table
 import dev.slne.surf.chat.api.message.MessageType
 import dev.slne.surf.chat.api.server.ChatServer
 import org.jetbrains.exposed.dao.id.IntIdTable
-import java.util.*
 
 object HistoryTable : IntIdTable("chat_history") {
-    val messageUuid =
-        varchar("message_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
-    val senderUuid =
-        varchar("sender_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
-    val receiverUuid =
-        varchar("receiver_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
-            .nullable()
+    val messageUuid = uuid("message_uuid").uniqueIndex()
+    val senderUuid = uuid("sender_uuid")
+    val receiverUuid = uuid("receiver_uuid").nullable()
     val message = text("message")
     val sentAt = long("sent_at")
-    val type = text("type").transform({ MessageType.valueOf(it) }, { it.name })
+    val type = enumeration<MessageType>("type")
     val server = text("server").transform({ ChatServer.of(it) }, { it.internalName })
     val channel = text("channel_name").nullable()
     val deletedBy = text("deleted_by").nullable()

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/IgnoreListTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/IgnoreListTable.kt
@@ -1,14 +1,13 @@
 package dev.slne.surf.chat.fallback.table
 
 import org.jetbrains.exposed.dao.id.IntIdTable
-import java.util.*
 
 object IgnoreListTable : IntIdTable("chat_ignorelist") {
     val userUuid =
-        varchar("user_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+        uuid("user_uuid")
     val userName = varchar("user_name", 16).default("Error")
     val targetUuid =
-        varchar("target_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+        uuid("target_uuid")
     val targetName = varchar("target_name", 16).default("Error")
     val createdAt = long("created_at")
 }

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/NotifySettingsTable.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/table/NotifySettingsTable.kt
@@ -1,11 +1,9 @@
 package dev.slne.surf.chat.fallback.table
 
 import org.jetbrains.exposed.dao.id.IntIdTable
-import java.util.*
 
 object NotifySettingsTable : IntIdTable("chat_settings_notify") {
-    val userUuid =
-        varchar("user_uuid", 36).transform({ UUID.fromString(it) }, { it.toString() })
+    val userUuid = uuid("user_uuid").uniqueIndex()
     val pingsEnabled = bool("pings_enabled").default(true)
     val invitesEnabled = bool("invites_enabled").default(true)
 }


### PR DESCRIPTION
This pull request updates the database schema and improves upsert operations in the fallback chat service. The main changes include switching UUID columns to use the native `uuid` type, adding unique indexes for better data integrity, and updating upsert calls to specify the row to update more precisely.

**Database schema improvements:**

* Changed all UUID columns in tables like `DMSettingsTable`, `HistoryTable`, `IgnoreListTable`, and `NotifySettingsTable` to use the native `uuid` type instead of storing UUIDs as strings, and added unique indexes where appropriate. [[1]](diffhunk://#diff-0ffe93a03aa23e9a316b42dd1b7c416f6bd4f320c5c6a84a3ad45242d88197cfL4-R6) [[2]](diffhunk://#diff-e4819136a1f6f477cbd9f48a8d9ec0b4f27cfc3a20b367b88e469fce1f194b18L6-R13) [[3]](diffhunk://#diff-fdf62e8d804b0ac93b68bfaff5295002f1f77b1cc7dc3c5c7ad93e2fca37e31aL4-R10) [[4]](diffhunk://#diff-f6d484d5486029eaea93e985f897757d29d0dc09cc17d72437427e27de46052cL4-R6)
* Added a unique index to the `server` column in `FunctionalityTable` to prevent duplicate server entries.

**Upsert operation improvements:**

* Updated all upsert calls in `FallbackFunctionalityService` and `FallbackNotificationService` to use the `where` parameter, ensuring updates target the correct row instead of potentially inserting duplicates. [[1]](diffhunk://#diff-08269b17df9ab521566a9154a5a5499b2b0cb184471ac7c323c047d51cc5a7cfL67-R67) [[2]](diffhunk://#diff-08269b17df9ab521566a9154a5a5499b2b0cb184471ac7c323c047d51cc5a7cfL78-R77) [[3]](diffhunk://#diff-08269b17df9ab521566a9154a5a5499b2b0cb184471ac7c323c047d51cc5a7cfL91-R89) [[4]](diffhunk://#diff-6412414fe3a34c1fbe57d655b2ea193e5a61de04fc200c881340c41d5fd11dacL30-R37) [[5]](diffhunk://#diff-6412414fe3a34c1fbe57d655b2ea193e5a61de04fc200c881340c41d5fd11dacL52-R58)

**Other schema enhancements:**

* Changed the `type` column in `HistoryTable` to use an enumeration for `MessageType` instead of storing as text, improving type safety and query performance.