### PR TITLE
Feat/add miniplaceholders hook

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,11 @@
 [versions]
 playerholder-api = "2.11.6"
+miniplaceholder-api = "3.0.1"
+miniplaceholder-kotlin = "3.0.1"
 surf-database = "2.0.4-SNAPSHOT"
 
 [libraries]
 playerholder-api = { module = "me.clip:placeholderapi", version.ref = "playerholder-api" }
+miniplaceholder-api = { module = "io.github.miniplaceholders:miniplaceholders-api", version.ref = "miniplaceholder-api" }
+miniplaceholder-kotlin = { module = "io.github.miniplaceholders:miniplaceholders-kotlin-ext", version.ref = "miniplaceholder-kotlin" }
 surf-database = { module = "dev.slne.surf:surf-database", version.ref = "surf-database" }

--- a/surf-chat-bukkit/build.gradle.kts
+++ b/surf-chat-bukkit/build.gradle.kts
@@ -21,5 +21,9 @@ surfPaperPluginApi {
     foliaSupported(true)
     generateLibraryLoader(false)
 
+    serverDependencies {
+        register("MiniPlaceholders")
+    }
+
     authors.add("red")
 }

--- a/surf-chat-bukkit/build.gradle.kts
+++ b/surf-chat-bukkit/build.gradle.kts
@@ -8,7 +8,11 @@ repositories {
 
 dependencies {
     api(project(":surf-chat-core"))
+
     compileOnly(libs.playerholder.api)
+    compileOnly(libs.miniplaceholder.api)
+    compileOnly(libs.miniplaceholder.kotlin)
+
     runtimeOnly(project(":surf-chat-fallback"))
 }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/configs/ConnectionMessageConfig.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/configs/ConnectionMessageConfig.kt
@@ -7,6 +7,6 @@ import org.spongepowered.configurate.objectmapping.ConfigSerializable
 @ConfigSerializable
 data class ConnectionMessageConfig(
     val enabled: Boolean = true,
-    val joinMessage: String = "${Colors.DARK_SPACER.miniMessage()}[${Colors.GREEN.miniMessage()}+${Colors.DARK_SPACER.miniMessage()}] %luckperms_prefix% %player_name%",
-    val leaveMessage: String = "${Colors.DARK_SPACER.miniMessage()}[${Colors.RED.miniMessage()}-${Colors.DARK_SPACER.miniMessage()}] %luckperms_prefix% %player_name%",
+    val joinMessage: String = "${Colors.DARK_SPACER.miniMessage()}[${Colors.GREEN.miniMessage()}+${Colors.DARK_SPACER.miniMessage()}] <luckperms_prefix> <player_name>",
+    val leaveMessage: String = "${Colors.DARK_SPACER.miniMessage()}[${Colors.RED.miniMessage()}-${Colors.DARK_SPACER.miniMessage()}] <luckperms_prefix> <player_name>",
 )

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/hook/MiniPlaceholdersHook.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/hook/MiniPlaceholdersHook.kt
@@ -1,0 +1,29 @@
+package dev.slne.surf.chat.bukkit.hook
+
+import io.github.miniplaceholders.api.MiniPlaceholders
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
+import org.bukkit.Bukkit
+import org.bukkit.entity.Player
+
+object MiniPlaceholdersHook {
+    private fun isEnabled() = Bukkit.getPluginManager().isPluginEnabled("MiniPlaceholders")
+
+    fun parseAudience(player: Player, input: String): Component {
+        if (!this.isEnabled()) {
+            return MiniMessage.miniMessage().deserialize(input)
+        }
+
+        val resolver = MiniPlaceholders.audiencePlaceholders()
+        return MiniMessage.miniMessage().deserialize(input, player, resolver)
+    }
+
+    fun parseGlobal(input: String): Component {
+        if (!this.isEnabled()) {
+            return MiniMessage.miniMessage().deserialize(input)
+        }
+
+        val resolver = MiniPlaceholders.globalPlaceholders()
+        return MiniMessage.miniMessage().deserialize(input, resolver)
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ConnectListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/ConnectListener.kt
@@ -1,14 +1,13 @@
 package dev.slne.surf.chat.bukkit.listener
 
 import com.github.shynixn.mccoroutine.folia.launch
-import dev.slne.surf.chat.bukkit.hook.PlaceholderAPIHook
+import dev.slne.surf.chat.bukkit.hook.MiniPlaceholdersHook
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.bukkit.pluginmessage.pluginMessageSender
 import dev.slne.surf.chat.core.Constants
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
@@ -29,10 +28,9 @@ class ConnectListener : Listener {
 
         if (plugin.connectionMessageConfig.enabled) {
             event.joinMessage(
-                PlaceholderAPIHook.parse(
+                MiniPlaceholdersHook.parseAudience(
                     event.player,
-                    MiniMessage.miniMessage()
-                        .deserialize(plugin.connectionMessageConfig.joinMessage)
+                    plugin.connectionMessageConfig.joinMessage
                 )
             )
         }
@@ -40,11 +38,9 @@ class ConnectListener : Listener {
         if (plugin.chatMotdConfig.enabled) {
             event.player.sendText {
                 append(
-                    MiniMessage.miniMessage().deserialize(
-                        PlaceholderAPIHook.parse(
-                            event.player,
-                            plugin.chatMotdConfig.message
-                        )
+                    MiniPlaceholdersHook.parseAudience(
+                        event.player,
+                        plugin.chatMotdConfig.message
                     )
                 )
             }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/DisconnectListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/DisconnectListener.kt
@@ -1,10 +1,9 @@
 package dev.slne.surf.chat.bukkit.listener
 
-import dev.slne.surf.chat.bukkit.hook.PlaceholderAPIHook
+import dev.slne.surf.chat.bukkit.hook.MiniPlaceholdersHook
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.bukkit.util.user
 import dev.slne.surf.chat.core.service.channelService
-import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerQuitEvent
@@ -20,10 +19,9 @@ class DisconnectListener : Listener {
 
         if (plugin.connectionMessageConfig.enabled) {
             event.quitMessage(
-                PlaceholderAPIHook.parse(
+                MiniPlaceholdersHook.parseAudience(
                     event.player,
-                    MiniMessage.miniMessage()
-                        .deserialize(plugin.connectionMessageConfig.leaveMessage)
+                    plugin.connectionMessageConfig.leaveMessage
                 )
             )
         }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
@@ -67,7 +67,7 @@ fun SurfComponentBuilder.appendMessageData(messageData: MessageData) = append(bu
 
 fun SurfComponentBuilder.appendName(player: Player) = append {
     append(
-        MiniPlaceholdersHook.parseAudience(player, "%luckperms_prefix% %player_name%")
+        MiniPlaceholdersHook.parseAudience(player, "<luckperms_prefix> <player_name>")
     )
 }
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/util/components.kt
@@ -3,7 +3,7 @@ package dev.slne.surf.chat.bukkit.util
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.chat.api.channel.Channel
 import dev.slne.surf.chat.api.entity.User
-import dev.slne.surf.chat.bukkit.hook.PlaceholderAPIHook
+import dev.slne.surf.chat.bukkit.hook.MiniPlaceholdersHook
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.core.message.MessageData
@@ -15,7 +15,6 @@ import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 import net.kyori.adventure.text.event.ClickEvent
 import net.kyori.adventure.text.format.TextDecoration
-import net.kyori.adventure.text.minimessage.MiniMessage
 import org.bukkit.Bukkit
 import org.bukkit.entity.Player
 
@@ -68,14 +67,7 @@ fun SurfComponentBuilder.appendMessageData(messageData: MessageData) = append(bu
 
 fun SurfComponentBuilder.appendName(player: Player) = append {
     append(
-        MiniMessage.miniMessage().deserialize(
-            convertLegacy(
-                PlaceholderAPIHook.parse(
-                    player,
-                    "%luckperms_prefix% %player_name%"
-                )
-            )
-        )
+        MiniPlaceholdersHook.parseAudience(player, "%luckperms_prefix% %player_name%")
     )
 }
 


### PR DESCRIPTION
This pull request updates the project to use MiniPlaceholders instead of PlaceholderAPI for placeholder parsing in chat messages. It introduces the MiniPlaceholders API and Kotlin extension as dependencies, updates configuration and message formats to the MiniPlaceholders syntax, and refactors relevant code to use the new hook. The changes also ensure MiniPlaceholders is registered as a server dependency.

**Dependency and Build Configuration Updates:**
- Added `miniplaceholders-api` and `miniplaceholders-kotlin-ext` as dependencies in `gradle/libs.versions.toml` and included them in the `surf-chat-bukkit` module's build configuration. Registered MiniPlaceholders as a server dependency. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR3-R10) [[2]](diffhunk://#diff-8eb7c3c26ffd52848ef80b857342000f1e7db70d1bc175c6031a2bfe001b013bR11-R15) [[3]](diffhunk://#diff-8eb7c3c26ffd52848ef80b857342000f1e7db70d1bc175c6031a2bfe001b013bR24-R27)

**Placeholder Parsing Refactor:**
- Replaced all usages of `PlaceholderAPIHook` with the new `MiniPlaceholdersHook` throughout the codebase, including in event listeners and utility functions. [[1]](diffhunk://#diff-db3615bae2210977a9c595a6e7424f31ff46a1a631161fee02f4261365a618ffL4-L11) [[2]](diffhunk://#diff-db3615bae2210977a9c595a6e7424f31ff46a1a631161fee02f4261365a618ffL32-L49) [[3]](diffhunk://#diff-4ef4c48c5bc2193e323192540d03d2a7f08c471fe2b7d75b9a40c80e285821cbL3-L7) [[4]](diffhunk://#diff-4ef4c48c5bc2193e323192540d03d2a7f08c471fe2b7d75b9a40c80e285821cbL23-R24) [[5]](diffhunk://#diff-280e1fba11baf357bdc318c363efc07f99cdbe1bd4c761c459fb776d7b1aa51aL6-R6) [[6]](diffhunk://#diff-280e1fba11baf357bdc318c363efc07f99cdbe1bd4c761c459fb776d7b1aa51aL18) [[7]](diffhunk://#diff-280e1fba11baf357bdc318c363efc07f99cdbe1bd4c761c459fb776d7b1aa51aL71-R70)

**Configuration and Message Format Changes:**
- Updated connection message configuration defaults to use MiniPlaceholders syntax (`<luckperms_prefix> <player_name>`) instead of PlaceholderAPI (`%luckperms_prefix% %player_name%`).

**New MiniPlaceholders Hook Implementation:**
- Added `MiniPlaceholdersHook.kt`, which provides static methods to parse placeholders for both player-specific and global contexts, using MiniPlaceholders if available, with fallback to plain MiniMessage parsing.