### PR TITLE
ci: update `MODULE_REGEX` to match `*-all.jar` artifacts in publish w…

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ env:
   SLNE_SNAPSHOTS_REPO_PASSWORD: ${{ secrets.SLNE_SNAPSHOTS_REPO_PASSWORD }}
   SLNE_RELEASES_REPO_USERNAME: ${{ secrets.SLNE_RELEASES_REPO_USERNAME }}
   SLNE_RELEASES_REPO_PASSWORD: ${{ secrets.SLNE_RELEASES_REPO_PASSWORD }}
-  MODULE_REGEX: "surf-chat-api.*\\.jar$|surf-chat-bukkit.*\\.jar$|surf-chat-velocity.*\\.jar$"
+  MODULE_REGEX: "surf-chat-api.*-all\\.jar$|surf-chat-bukkit.*-all\\.jar$|surf-chat-velocity.*-all\\.jar$"
   DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:


### PR DESCRIPTION
This pull request makes a minor update to the `MODULE_REGEX` environment variable in the `.github/workflows/publish.yml` file. The change ensures that only JAR files with the `-all` suffix are matched, likely to restrict publishing to shaded or bundled JARs rather than all JARs.

- Updated `MODULE_REGEX` to only match JAR files ending with `-all.jar` for the `surf-chat-api`, `surf-chat-bukkit`, and `surf-chat-velocity` modules in the GitHub Actions publish workflow.