### PR TITLE
Feat/add default denylist actions and entries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.8-4.0.2-SNAPSHOT
+version=1.21.8-4.0.3-SNAPSHOT

--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/entry/DenylistActionType.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/entry/DenylistActionType.kt
@@ -39,5 +39,16 @@ enum class DenylistActionType {
      * without enforcing stricter actions such as banning or muting. Warnings are generally
      * used as a preliminary measure in moderation workflows.
      */
-    WARN
+    WARN,
+
+    /**
+     * Represents a community ban action type.
+     *
+     * This action type is used to enforce a ban across an entire community or platform,
+     * rather than just a single server or chat instance. It is typically applied for severe
+     * violations of community guidelines or rules.
+     *
+     * Note: Triggering a community ban can broadcast a message to discord
+     */
+    COMMUNITY_BAN
 }

--- a/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/entry/DenylistActionType.kt
+++ b/surf-chat-api/src/main/kotlin/dev/slne/surf/chat/api/entry/DenylistActionType.kt
@@ -14,7 +14,16 @@ enum class DenylistActionType {
      * based on the denylist conditions. It is part of the `DenylistActionType` enumeration
      * and is typically utilized in systems for moderating and managing user behavior.
      */
-    BAN,
+    EXPIREABLE_BAN,
+
+    /**
+     * Represents a permanent ban action type within the denylist system.
+     *
+     * This action type is used to permanently prevent a user from accessing certain features
+     * or areas of the system based on the denylist conditions. Unlike temporary bans, this
+     * action has no expiration and is intended for severe or repeated violations of the system's policies.
+     */
+    PERMANENT_BAN,
 
     /**
      * Represents the action of kicking a user from a chat or server.

--- a/surf-chat-bukkit/build.gradle.kts
+++ b/surf-chat-bukkit/build.gradle.kts
@@ -21,6 +21,7 @@ surfPaperPluginApi {
     mainClass("dev.slne.surf.chat.bukkit.BukkitMain")
     foliaSupported(true)
     generateLibraryLoader(false)
+    withCloudCommon()
 
     serverDependencies {
         registerSoft("MiniPlaceholders")

--- a/surf-chat-bukkit/build.gradle.kts
+++ b/surf-chat-bukkit/build.gradle.kts
@@ -1,3 +1,5 @@
+import dev.slne.surf.surfapi.gradle.util.registerSoft
+
 plugins {
     id("dev.slne.surf.surfapi.gradle.paper-plugin")
 }
@@ -21,7 +23,7 @@ surfPaperPluginApi {
     generateLibraryLoader(false)
 
     serverDependencies {
-        register("MiniPlaceholders")
+        registerSoft("MiniPlaceholders")
     }
 
     authors.add("red")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
@@ -3,8 +3,8 @@ package dev.slne.surf.chat.bukkit
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.chat.api.server.ChatServer
+import dev.slne.surf.chat.bukkit.config.DiscordConfigProvider
 import dev.slne.surf.chat.bukkit.config.SurfChatConfigProvider
-import dev.slne.surf.chat.bukkit.config.configs.DiscordConfig
 import dev.slne.surf.chat.core.service.databaseService
 import dev.slne.surf.chat.core.service.denylistActionService
 import dev.slne.surf.chat.core.service.denylistService
@@ -45,7 +45,7 @@ class BukkitMain : SuspendingJavaPlugin() {
     }
 
     val surfChatConfig = SurfChatConfigProvider()
-    val discordConfig = DiscordConfig()
+    val discordConfig = DiscordConfigProvider()
     val connectionMessageConfig get() = surfChatConfig.config.connectionMessageConfig
     val chatMotdConfig get() = surfChatConfig.config.chatMotdConfig
     val chatServerConfig get() = surfChatConfig.config.chatServerConfig

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/BukkitMain.kt
@@ -4,6 +4,7 @@ import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.chat.api.server.ChatServer
 import dev.slne.surf.chat.bukkit.config.SurfChatConfigProvider
+import dev.slne.surf.chat.bukkit.config.configs.DiscordConfig
 import dev.slne.surf.chat.core.service.databaseService
 import dev.slne.surf.chat.core.service.denylistActionService
 import dev.slne.surf.chat.core.service.denylistService
@@ -44,6 +45,7 @@ class BukkitMain : SuspendingJavaPlugin() {
     }
 
     val surfChatConfig = SurfChatConfigProvider()
+    val discordConfig = DiscordConfig()
     val connectionMessageConfig get() = surfChatConfig.config.connectionMessageConfig
     val chatMotdConfig get() = surfChatConfig.config.chatMotdConfig
     val chatServerConfig get() = surfChatConfig.config.chatServerConfig

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/DenylistActionTypeArgument.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/DenylistActionTypeArgument.kt
@@ -15,10 +15,11 @@ class DenylistActionTypeArgument(nodeName: String) :
             "ban" -> DenylistActionType.BAN
             "mute" -> DenylistActionType.MUTE
             "warn" -> DenylistActionType.WARN
+            "communityban" -> DenylistActionType.COMMUNITY_BAN
             else -> throw CustomArgumentException.fromAdventureComponent {
                 buildText {
                     appendPrefix()
-                    error("Der Aktionstyp '${info.input()}' ist ungültig. Gültige Typen sind: kick, ban, mute, warn")
+                    error("Der Aktionstyp '${info.input()}' ist ungültig. Gültige Typen sind: kick, ban, mute, warn, communityban")
                 }
             }
         }
@@ -29,7 +30,8 @@ class DenylistActionTypeArgument(nodeName: String) :
                 "kick",
                 "ban",
                 "mute",
-                "warn"
+                "warn",
+                "communityban"
             )
         )
     }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/DenylistActionTypeArgument.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/argument/DenylistActionTypeArgument.kt
@@ -12,14 +12,15 @@ class DenylistActionTypeArgument(nodeName: String) :
     CustomArgument<DenylistActionType, String>(StringArgument(nodeName), { info ->
         when (info.input()) {
             "kick" -> DenylistActionType.KICK
-            "ban" -> DenylistActionType.BAN
+            "ban" -> DenylistActionType.EXPIREABLE_BAN
             "mute" -> DenylistActionType.MUTE
             "warn" -> DenylistActionType.WARN
             "communityban" -> DenylistActionType.COMMUNITY_BAN
+            "ban-permanent" -> DenylistActionType.PERMANENT_BAN
             else -> throw CustomArgumentException.fromAdventureComponent {
                 buildText {
                     appendPrefix()
-                    error("Der Aktionstyp '${info.input()}' ist ungültig. Gültige Typen sind: kick, ban, mute, warn, communityban")
+                    error("Der Aktionstyp '${info.input()}' ist ungültig. Gültige Typen sind: kick, ban, mute, warn, communityban, ban-permanent.")
                 }
             }
         }
@@ -31,7 +32,8 @@ class DenylistActionTypeArgument(nodeName: String) :
                 "ban",
                 "mute",
                 "warn",
-                "communityban"
+                "communityban",
+                "ban-permanent"
             )
         )
     }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistClearCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistClearCommand.kt
@@ -1,0 +1,47 @@
+package dev.slne.surf.chat.bukkit.command.denylist
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.core.service.denylistService
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import net.kyori.adventure.text.event.ClickEvent
+import org.bukkit.entity.Player
+
+fun CommandAPICommand.denylistClearCommand() = subcommand("clear") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_CLEAR)
+    anyExecutor { executor, _ ->
+        if (executor is Player) {
+            executor.sendText {
+                appendPrefix()
+                info("Möchtest du die Denylist wirklich leeren? ")
+                append {
+                    spacer("[")
+                    success("Bestätigen")
+                    spacer("]")
+                    clickEvent(ClickEvent.callback {
+                        plugin.launch {
+                            denylistService.clearEntries()
+                            executor.sendText {
+                                appendPrefix()
+                                success("Die Denylist wurde geleert.")
+                            }
+                        }
+                    })
+                }
+            }
+            return@anyExecutor
+        }
+
+        plugin.launch {
+            denylistService.clearEntries()
+            executor.sendText {
+                appendPrefix()
+                success("Die Denylist wurde geleert.")
+            }
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistCommand.kt
@@ -10,4 +10,6 @@ fun denylistCommand() = commandAPICommand("denylist", plugin) {
     denylistRemoveCommand()
     denylistFetchCommand()
     denylistListCommand()
+    denylistClearCommand()
+    denylistImportDefaultCommand()
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
@@ -10,7 +10,6 @@ import dev.slne.surf.chat.bukkit.plugin
 import dev.slne.surf.chat.core.entry.DenylistBatchEntry
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import kotlinx.coroutines.Dispatchers
-import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 
 /**
@@ -55,7 +54,6 @@ fun CommandAPICommand.denylistImportDefaultCommand() = subcommand("importdefault
                     .withStaff("Arty Support")
                     .withActionType(DenylistActionType.COMMUNITY_BAN)
                     .withPunishReason("Rassistische oder extremistische Inhalte")
-                    .withDuration(Duration.INFINITE)
                     .withWords(
                         "nigger",
                         "ngga",
@@ -70,7 +68,7 @@ fun CommandAPICommand.denylistImportDefaultCommand() = subcommand("importdefault
                 DenylistBatchEntry.builder()
                     .withReason("Starke Beleidigungen")
                     .withStaff("Arty Support")
-                    .withActionType(DenylistActionType.BAN)
+                    .withActionType(DenylistActionType.EXPIREABLE_BAN)
                     .withPunishReason("Inhalte mit abwertender, beleidigender oder diskriminierender Sprache")
                     .withDuration(14.days)
                     .withWords(
@@ -85,7 +83,7 @@ fun CommandAPICommand.denylistImportDefaultCommand() = subcommand("importdefault
                 DenylistBatchEntry.builder()
                     .withReason("Mittelstarke Beleidigungen")
                     .withStaff("Arty Support")
-                    .withActionType(DenylistActionType.BAN)
+                    .withActionType(DenylistActionType.EXPIREABLE_BAN)
                     .withPunishReason("Inhalte mit persönlichen Beleidigungen mittlerer Stufe")
                     .withDuration(7.days)
                     .withWords(

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
@@ -58,11 +58,18 @@ fun CommandAPICommand.denylistImportDefaultCommand() = subcommand("importdefault
                         "nigger",
                         "ngga",
                         "nigga",
-                        "kys",
-                        "killyourself",
-                        "kill yourself",
                         "hh",
                         "heil hitler"
+                    )
+                    .build(),
+                DenylistBatchEntry.builder()
+                    .withReason("Gewaltverherrlichende Inhalte")
+                    .withStaff("Arty Support")
+                    .withActionType(DenylistActionType.PERMANENT_BAN)
+                    .withPunishReason("Gewaltverherrlichende Inhalte")
+                    .withWords(
+                        "killyourself",
+                        "kys",
                     )
                     .build(),
                 DenylistBatchEntry.builder()

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
@@ -1,0 +1,117 @@
+package dev.slne.surf.chat.bukkit.command.denylist
+
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.chat.api.entry.DenylistActionType
+import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.core.entry.DenylistBatchEntry
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import kotlinx.coroutines.Dispatchers
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+
+/**
+ * ⚠️ DISCLAIMER:
+ *
+ * All offensive words, swear words, or potentially sensitive language contained
+ * in this file exist **solely for the purpose of moderation, testing, and
+ * functional operation of this plugin**. They are included to ensure that
+ * the plugin can properly detect, handle, and respond to such language
+ * where necessary.
+ *
+ * Under no circumstances are these words intended to insult, harm, or
+ * demean any individual, group, or community. Their presence is strictly
+ * technical and functional, and any resemblance to real-life offensive
+ * language is purely coincidental.
+ *
+ * This file and its contents are designed for controlled and responsible
+ * usage within the plugin's systems. Any use outside of this intended
+ * context is **unauthorized and unintended**.
+ *
+ * By including these words, the goal is to improve moderation capabilities
+ * and ensure the plugin behaves correctly in scenarios where offensive
+ * language might appear—not to promote or normalize inappropriate speech.
+ *
+ * ⚠️ Please treat all content in this file as **strictly functional**,
+ * not personal or offensive.
+ */
+
+
+fun CommandAPICommand.denylistImportDefaultCommand() = subcommand("importdefaults") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_DEFAULTS)
+    anyExecutor { executor, _ ->
+        executor.sendText {
+            appendPrefix()
+            info("Importiere Standard-Wortfilter...")
+        }
+
+        plugin.launch(Dispatchers.IO) {
+            listOf(
+                DenylistBatchEntry.builder()
+                    .withReason("Rassismus, Extremismus, Gewalt")
+                    .withStaff("Arty Support")
+                    .withActionType(DenylistActionType.COMMUNITY_BAN)
+                    .withPunishReason("Rassistische oder extremistische Inhalte")
+                    .withDuration(Duration.INFINITE)
+                    .withWords(
+                        "nigger",
+                        "ngga",
+                        "nigga",
+                        "kys",
+                        "killyourself",
+                        "kill yourself",
+                        "hh",
+                        "heil hitler"
+                    )
+                    .build(),
+                DenylistBatchEntry.builder()
+                    .withReason("Starke Beleidigungen")
+                    .withStaff("Arty Support")
+                    .withActionType(DenylistActionType.BAN)
+                    .withPunishReason("Inhalte mit abwertender, beleidigender oder diskriminierender Sprache")
+                    .withDuration(14.days)
+                    .withWords(
+                        "hure",
+                        "hurensohn",
+                        "fotze",
+                        "nutte",
+                        "bastard",
+                        "schlampe",
+                        "hs"
+                    ).build(),
+                DenylistBatchEntry.builder()
+                    .withReason("Mittelstarke Beleidigungen")
+                    .withStaff("Arty Support")
+                    .withActionType(DenylistActionType.BAN)
+                    .withPunishReason("Inhalte mit persönlichen Beleidigungen mittlerer Stufe")
+                    .withDuration(7.days)
+                    .withWords(
+                        "ass", "arschloch", "arsch", "opfer", "wichser", "pisser", "pussy"
+                    ).build(),
+                DenylistBatchEntry.builder()
+                    .withReason("Leichte Beleidigungen")
+                    .withStaff("Arty Support")
+                    .withActionType(DenylistActionType.MUTE)
+                    .withPunishReason("Beleidigende Inhalte")
+                    .withDuration(3.days)
+                    .withWords(
+                        "dummkopf",
+                        "idiot",
+                        "miststück",
+                        "blödmann",
+                        "verpiss dich",
+                        "verpissdich",
+                        "loser",
+                        "noob",
+                        "n00b",
+                        "leck"
+                    ).build()
+            ).forEach { entry ->
+                entry.execute()
+            }
+        }
+    }
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
@@ -112,6 +112,11 @@ fun CommandAPICommand.denylistImportDefaultCommand() = subcommand("importdefault
             ).forEach { entry ->
                 entry.execute()
             }
+
+            executor.sendText {
+                appendPrefix()
+                success("Import der Standard-Wortfilter abgeschlossen.")
+            }
         }
     }
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionClearCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionClearCommand.kt
@@ -39,7 +39,7 @@ fun CommandAPICommand.denylistActionClearCommand() = subcommand("clear") {
         }
 
         plugin.launch {
-            denylistService.clearEntries()
+            denylistActionService.clearActions()
             executor.sendText {
                 appendPrefix()
                 success("Die Denylist Aktionen wurde geleert.")

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionClearCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionClearCommand.kt
@@ -1,4 +1,4 @@
-package dev.slne.surf.chat.bukkit.command.denylist
+package dev.slne.surf.chat.bukkit.command.denylist.action
 
 import com.github.shynixn.mccoroutine.folia.launch
 import dev.jorel.commandapi.CommandAPICommand
@@ -6,29 +6,30 @@ import dev.jorel.commandapi.kotlindsl.anyExecutor
 import dev.jorel.commandapi.kotlindsl.subcommand
 import dev.slne.surf.chat.bukkit.permission.SurfChatPermissionRegistry
 import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.chat.core.service.denylistActionService
 import dev.slne.surf.chat.core.service.denylistService
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import net.kyori.adventure.text.event.ClickEvent
 import org.bukkit.entity.Player
 
-fun CommandAPICommand.denylistClearCommand() = subcommand("clear") {
-    withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_CLEAR)
+fun CommandAPICommand.denylistActionClearCommand() = subcommand("clear") {
+    withPermission(SurfChatPermissionRegistry.COMMAND_DENYLIST_ACTION_CLEAR)
     anyExecutor { executor, _ ->
         if (executor is Player) {
             executor.sendText {
                 appendPrefix()
-                info("Möchtest du die Denylist wirklich leeren? ")
+                info("Möchtest du die Denylist Aktionen wirklich leeren? ")
                 append {
                     spacer("[")
                     success("Bestätigen")
                     spacer("]")
                     clickEvent(ClickEvent.callback {
                         plugin.launch {
-                            denylistService.clearEntries()
-                            denylistService.clearLocalEntries()
+                            denylistActionService.clearActions()
+                            denylistActionService.clearLocalActions()
                             executor.sendText {
                                 appendPrefix()
-                                success("Die Denylist wurde geleert.")
+                                success("Die Denylist Aktionen wurde geleert.")
                             }
                         }
                     })
@@ -41,7 +42,7 @@ fun CommandAPICommand.denylistClearCommand() = subcommand("clear") {
             denylistService.clearEntries()
             executor.sendText {
                 appendPrefix()
-                success("Die Denylist wurde geleert.")
+                success("Die Denylist Aktionen wurde geleert.")
             }
         }
     }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/action/DenylistActionCommand.kt
@@ -10,4 +10,5 @@ fun denylistActionCommand() = commandAPICommand("denylistaction") {
     denylistActionRemoveCommand()
     denylistActionFetchCommand()
     denylistActionListCommand()
+    denylistActionClearCommand()
 }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatReloadCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/surfchat/SurfChatReloadCommand.kt
@@ -15,6 +15,7 @@ fun CommandAPICommand.surfChatReloadCommand() = subcommand("reload") {
     anyExecutor { executor, _ ->
         val ms = measureTimeMillis {
             plugin.surfChatConfig.reload()
+            plugin.discordConfig.reload()
 
             ConnectListener.ALREADY_REQUESTED = false
         }

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/DiscordConfigProvider.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/DiscordConfigProvider.kt
@@ -1,0 +1,28 @@
+package dev.slne.surf.chat.bukkit.config
+
+import dev.slne.surf.chat.bukkit.config.configs.DiscordConfig
+import dev.slne.surf.chat.bukkit.plugin
+import dev.slne.surf.surfapi.core.api.config.manager.SpongeConfigManager
+import dev.slne.surf.surfapi.core.api.config.surfConfigApi
+
+class DiscordConfigProvider {
+    private val configManager: SpongeConfigManager<DiscordConfig>
+
+    init {
+        surfConfigApi.createSpongeYmlConfig(
+            DiscordConfig::class.java,
+            plugin.dataPath,
+            "discord.yml"
+        )
+        configManager = surfConfigApi.getSpongeConfigManagerForConfig(
+            DiscordConfig::class.java
+        )
+        reload()
+    }
+
+    fun reload() {
+        configManager.reloadFromFile()
+    }
+
+    val config get() = configManager.config
+}

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/configs/DiscordConfig.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/config/configs/DiscordConfig.kt
@@ -1,0 +1,9 @@
+package dev.slne.surf.chat.bukkit.config.configs
+
+import org.spongepowered.configurate.objectmapping.ConfigSerializable
+
+@ConfigSerializable
+data class DiscordConfig(
+    val enabled: Boolean = false,
+    val webhook: String = ""
+)

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
@@ -52,7 +52,8 @@ class AsyncChatListener : Listener {
                         messageId,
                         error.denylistEntry,
                         event.signedMessage(),
-                        user
+                        user,
+                        if (plugin.discordConfig.enabled) plugin.discordConfig.webhook else null
                     )
                 }
             } else {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/listener/AsyncChatListener.kt
@@ -53,7 +53,7 @@ class AsyncChatListener : Listener {
                         error.denylistEntry,
                         event.signedMessage(),
                         user,
-                        if (plugin.discordConfig.enabled) plugin.discordConfig.webhook else null
+                        if (plugin.discordConfig.config.enabled) plugin.discordConfig.config.webhook else null
                     )
                 }
             } else {

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
@@ -45,6 +45,7 @@ object SurfChatPermissionRegistry : PermissionRegistry() {
     val COMMAND_DENYLIST_ACTION_REMOVE = create("$PREFIX_COMMAND.denylist.action.remove")
     val COMMAND_DENYLIST_ACTION_LIST = create("$PREFIX_COMMAND.denylist.action.list")
     val COMMAND_DENYLIST_ACTION_FETCH = create("$PREFIX_COMMAND.denylist.action.fetch")
+    val COMMAND_DENYLIST_ACTION_CLEAR = create("$PREFIX_COMMAND.denylist.action.clear")
     val COMMAND_DENYLIST_DEFAULTS = create("$PREFIX_COMMAND.denylist.defaults")
     val COMMAND_DENYLIST_CLEAR = create("$PREFIX_COMMAND.denylist.clear")
 

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/permission/SurfChatPermissionRegistry.kt
@@ -45,6 +45,8 @@ object SurfChatPermissionRegistry : PermissionRegistry() {
     val COMMAND_DENYLIST_ACTION_REMOVE = create("$PREFIX_COMMAND.denylist.action.remove")
     val COMMAND_DENYLIST_ACTION_LIST = create("$PREFIX_COMMAND.denylist.action.list")
     val COMMAND_DENYLIST_ACTION_FETCH = create("$PREFIX_COMMAND.denylist.action.fetch")
+    val COMMAND_DENYLIST_DEFAULTS = create("$PREFIX_COMMAND.denylist.defaults")
+    val COMMAND_DENYLIST_CLEAR = create("$PREFIX_COMMAND.denylist.clear")
 
     val COMMAND_DIRECT_SPY = create("$PREFIX_COMMAND.direct-spy")
     val COMMAND_DIRECT_SPY_CLEAR = create("$PREFIX_COMMAND.direct-spy.clear")

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistBatchEntry.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistBatchEntry.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.chat.core.entry
 import dev.slne.surf.chat.api.DenylistAction
 import dev.slne.surf.chat.api.entry.DenylistActionType
 import dev.slne.surf.chat.api.entry.DenylistEntry
+import dev.slne.surf.chat.core.service.denylistActionService
 import dev.slne.surf.chat.core.service.denylistService
 import kotlin.time.Duration
 
@@ -22,7 +23,16 @@ class DenylistBatchEntry private constructor(
 
     suspend fun execute() {
         entries.forEach {
+            denylistActionService.addAction(it.action)
+            denylistActionService.addLocalAction(it.action)
             denylistService.addEntry(
+                it.word,
+                it.reason,
+                it.addedBy,
+                it.addedAt,
+                it.action
+            )
+            denylistService.addLocalEntry(
                 it.word,
                 it.reason,
                 it.addedBy,

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistBatchEntry.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistBatchEntry.kt
@@ -1,0 +1,89 @@
+package dev.slne.surf.chat.core.entry
+
+import dev.slne.surf.chat.api.DenylistAction
+import dev.slne.surf.chat.api.entry.DenylistActionType
+import dev.slne.surf.chat.api.entry.DenylistEntry
+import dev.slne.surf.chat.core.service.denylistService
+import kotlin.time.Duration
+
+/**
+ * Represents a batch of denylist entries created together.
+ *
+ * The builder allows fluent creation of multiple denylist entries that share
+ * the same metadata (reason, staff, action type, etc.).
+ */
+class DenylistBatchEntry private constructor(
+    val entries: List<DenylistEntry>
+) {
+    companion object {
+        @JvmStatic
+        fun builder(): Builder = Builder()
+    }
+
+    suspend fun execute() {
+        entries.forEach {
+            denylistService.addEntry(
+                it.word,
+                it.reason,
+                it.addedBy,
+                it.addedAt,
+                it.action
+            )
+        }
+    }
+
+    class Builder {
+        private val words = mutableListOf<String>()
+        private var reason: String = "No reason specified"
+        private var staff: String = "System"
+        private var actionType: DenylistActionType = DenylistActionType.WARN
+        private var punishReason: String = "No punish reason specified"
+        private var duration: Long = 0L
+
+        fun withWords(vararg words: String) = apply {
+            this.words.addAll(words)
+        }
+
+        fun withReason(reason: String) = apply {
+            this.reason = reason
+        }
+
+        fun withStaff(staff: String) = apply {
+            this.staff = staff
+        }
+
+        fun withActionType(actionType: DenylistActionType) = apply {
+            this.actionType = actionType
+        }
+
+        fun withPunishReason(punishReason: String) = apply {
+            this.punishReason = punishReason
+        }
+
+        fun withDuration(duration: Duration) = apply {
+            this.duration = duration.inWholeMilliseconds
+        }
+
+        fun build(): DenylistBatchEntry {
+            val now = System.currentTimeMillis()
+            val action: DenylistAction = DenylistActionImpl(
+                name = "default-${actionType.name.lowercase()}-$duration",
+                actionType = actionType,
+                reason = punishReason,
+                duration = duration
+            )
+
+            val entries = words.map { word ->
+                DenylistEntryImpl(
+                    word = word,
+                    reason = reason,
+                    addedBy = staff,
+                    addedAt = now,
+                    action = action
+                )
+            }
+
+            return DenylistBatchEntry(entries)
+        }
+    }
+}

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistBatchEntry.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistBatchEntry.kt
@@ -14,6 +14,7 @@ import kotlin.time.Duration
  * the same metadata (reason, staff, action type, etc.).
  */
 class DenylistBatchEntry private constructor(
+    val action: DenylistAction,
     val entries: List<DenylistEntry>
 ) {
     companion object {
@@ -22,9 +23,9 @@ class DenylistBatchEntry private constructor(
     }
 
     suspend fun execute() {
+        denylistActionService.addAction(action)
+        denylistActionService.addLocalAction(action)
         entries.forEach {
-            denylistActionService.addAction(it.action)
-            denylistActionService.addLocalAction(it.action)
             denylistService.addEntry(
                 it.word,
                 it.reason,
@@ -93,7 +94,7 @@ class DenylistBatchEntry private constructor(
                 )
             }
 
-            return DenylistBatchEntry(entries)
+            return DenylistBatchEntry(action, entries)
         }
     }
 }

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistBatchEntry.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/entry/DenylistBatchEntry.kt
@@ -78,7 +78,7 @@ class DenylistBatchEntry private constructor(
         fun build(): DenylistBatchEntry {
             val now = System.currentTimeMillis()
             val action: DenylistAction = DenylistActionImpl(
-                name = "default-${actionType.name.lowercase()}-$duration",
+                name = "${actionType.name.lowercase()}-$reason",
                 actionType = actionType,
                 reason = punishReason,
                 duration = duration

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DenylistActionService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DenylistActionService.kt
@@ -105,6 +105,25 @@ interface DenylistActionService {
      */
     fun hasLocalAction(name: String): Boolean
 
+    /**
+     * Clears all denylist entries from the system.
+     *
+     * This method removes all entries from persistent storage,
+     * effectively resetting the denylist to an empty state.
+     *
+     * @return The number of entries that were removed.
+     */
+    suspend fun clearActions(): Int
+
+    /**
+     * Removes all locally stored denylist actions from memory.
+     *
+     * This method clears the in-memory list of denylist actions managed by the
+     * local context. It does not affect actions stored persistently or remotely.
+     * Use this method to reset or refresh the locally tracked denylist state.
+     */
+    fun clearLocalActions()
+
 
     /**
      * Processes an action based on the provided denylist entry and message details.

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DenylistActionService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DenylistActionService.kt
@@ -122,7 +122,8 @@ interface DenylistActionService {
         messageUuid: UUID,
         entry: DenylistEntry,
         message: SignedMessage,
-        sender: User
+        sender: User,
+        discordHookUrl: String?
     )
 
     /**

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DenylistService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DenylistService.kt
@@ -84,6 +84,16 @@ interface DenylistService : DatabaseTableHolder {
     fun clearLocalEntries()
 
     /**
+     * Clears all denylist entries from the system.
+     *
+     * This method removes all entries from persistent storage,
+     * effectively resetting the denylist to an empty state.
+     *
+     * @return The number of entries that were removed.
+     */
+    suspend fun clearEntries(): Int
+
+    /**
      * Retrieves a list of locally-stored denylist entries.
      *
      * This function returns all denylist entries that have been added locally

--- a/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DiscordService.kt
+++ b/surf-chat-core/src/main/kotlin/dev/slne/surf/chat/core/service/DiscordService.kt
@@ -1,0 +1,15 @@
+package dev.slne.surf.chat.core.service
+
+import dev.slne.surf.chat.api.entity.User
+import dev.slne.surf.chat.api.entry.DenylistEntry
+import dev.slne.surf.surfapi.core.api.util.requiredService
+
+interface DiscordService {
+    suspend fun sendCommunityBanNotification(url: String, user: User, denylistEntry: DenylistEntry)
+
+    companion object {
+        val INSTANCE = requiredService<DiscordService>()
+    }
+}
+
+val discordService get() = DiscordService.INSTANCE

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistActionService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistActionService.kt
@@ -16,6 +16,7 @@ import dev.slne.surf.surfapi.core.api.util.logger
 import dev.slne.surf.surfapi.core.api.util.mutableObjectSetOf
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.util.Services
 import org.bukkit.Bukkit
@@ -80,13 +81,14 @@ class FallbackDenylistActionService : DenylistActionService, Services.Fallback {
         message: SignedMessage,
         sender: User,
         discordHookUrl: String?
-    ) {
+    ) = withContext(Dispatchers.IO) {
         if (isCloud()) {
+
             val cloudPlayer = sender.toOfflineCloudPlayer()
             val punishManager = cloudPlayer.punishmentManager
 
             when (entry.action.actionType) {
-                DenylistActionType.BAN -> {
+                DenylistActionType.EXPIREABLE_BAN -> {
                     punishManager.punish(
                         PunishType.BAN.Expirable(
                             ZonedDateTime.now().plus(
@@ -102,6 +104,14 @@ class FallbackDenylistActionService : DenylistActionService, Services.Fallback {
                 DenylistActionType.KICK -> {
                     punishManager.punish(
                         PunishType.KICK
+                            .withNote("Punished by Arty Support (surf-chat) for: ${entry.word} (messageUid: $messageUuid)"),
+                        entry.action.reason
+                    )
+                }
+
+                DenylistActionType.PERMANENT_BAN -> {
+                    punishManager.punish(
+                        PunishType.BAN.Permanent
                             .withNote("Punished by Arty Support (surf-chat) for: ${entry.word} (messageUid: $messageUuid)"),
                         entry.action.reason
                     )
@@ -130,12 +140,7 @@ class FallbackDenylistActionService : DenylistActionService, Services.Fallback {
 
                 DenylistActionType.COMMUNITY_BAN -> {
                     punishManager.punish(
-                        PunishType.BAN.Expirable(
-                            ZonedDateTime.now().plus(
-                                entry.action.duration,
-                                ChronoUnit.MILLIS
-                            )
-                        )
+                        PunishType.BAN.Permanent
                             .withNote("Punished by Arty Support (surf-chat) for: ${entry.word} (messageUid: $messageUuid)"),
                         entry.action.reason
                     )

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistActionService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistActionService.kt
@@ -6,6 +6,7 @@ import dev.slne.surf.chat.api.entity.User
 import dev.slne.surf.chat.api.entry.DenylistActionType
 import dev.slne.surf.chat.api.entry.DenylistEntry
 import dev.slne.surf.chat.core.service.DenylistActionService
+import dev.slne.surf.chat.core.service.discordService
 import dev.slne.surf.chat.core.service.historyService
 import dev.slne.surf.chat.fallback.entity.DenylistActionEntity
 import dev.slne.surf.chat.fallback.table.DenylistActionsTable
@@ -71,7 +72,8 @@ class FallbackDenylistActionService : DenylistActionService, Services.Fallback {
         messageUuid: UUID,
         entry: DenylistEntry,
         message: SignedMessage,
-        sender: User
+        sender: User,
+        discordHookUrl: String?
     ) {
         if (isCloud()) {
             val cloudPlayer = sender.toOfflineCloudPlayer()
@@ -118,6 +120,23 @@ class FallbackDenylistActionService : DenylistActionService, Services.Fallback {
                             .withNote("Punished by Arty Support (surf-chat) for: ${entry.word} (messageUid: $messageUuid)"),
                         entry.action.reason
                     )
+                }
+
+                DenylistActionType.COMMUNITY_BAN -> {
+                    punishManager.punish(
+                        PunishType.BAN.Expirable(
+                            ZonedDateTime.now().plus(
+                                entry.action.duration,
+                                ChronoUnit.MILLIS
+                            )
+                        )
+                            .withNote("Punished by Arty Support (surf-chat) for: ${entry.word} (messageUid: $messageUuid)"),
+                        entry.action.reason
+                    )
+
+                    discordHookUrl?.let {
+                        discordService.sendCommunityBanNotification(it, sender, entry)
+                    }
                 }
             }
         } else {

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistActionService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistActionService.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.delay
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.util.Services
 import org.bukkit.Bukkit
+import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import java.time.ZonedDateTime
 import java.time.temporal.ChronoUnit
@@ -28,7 +29,7 @@ import kotlin.time.Duration.Companion.seconds
 @Suppress("MISSING_DEPENDENCY_SUPERCLASS_IN_TYPE_ARGUMENT")
 @AutoService(DenylistActionService::class)
 class FallbackDenylistActionService : DenylistActionService, Services.Fallback {
-    val localActions = mutableObjectSetOf<DenylistAction>()
+    private val _actions = mutableObjectSetOf<DenylistAction>()
 
     override suspend fun addAction(action: DenylistAction) =
         newSuspendedTransaction(Dispatchers.IO) {
@@ -54,19 +55,24 @@ class FallbackDenylistActionService : DenylistActionService, Services.Fallback {
     }
 
     override suspend fun fetchActions() = newSuspendedTransaction(Dispatchers.IO) {
-        localActions.clear()
-        localActions.addAll(DenylistActionEntity.all().map {
+        _actions.clear()
+        _actions.addAll(DenylistActionEntity.all().map {
             it.toDto()
         })
         return@newSuspendedTransaction
     }
 
-    override fun addLocalAction(action: DenylistAction) = localActions.add(action)
-    override fun removeLocalAction(action: DenylistAction) = localActions.remove(action)
-    override fun getLocalAction(name: String) = localActions.firstOrNull { it.name == name }
+    override fun addLocalAction(action: DenylistAction) = _actions.add(action)
+    override fun removeLocalAction(action: DenylistAction) = _actions.remove(action)
+    override fun getLocalAction(name: String) = _actions.firstOrNull { it.name == name }
 
-    override fun listLocalActions() = localActions
-    override fun hasLocalAction(name: String) = localActions.any { it.name == name }
+    override fun listLocalActions() = _actions
+    override fun hasLocalAction(name: String) = _actions.any { it.name == name }
+    override suspend fun clearActions() = newSuspendedTransaction(Dispatchers.IO) {
+        DenylistActionsTable.deleteAll()
+    }
+
+    override fun clearLocalActions() = _actions.clear()
 
     override suspend fun makeAction(
         messageUuid: UUID,

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDenylistService.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import net.kyori.adventure.util.Services
 import org.jetbrains.exposed.sql.SchemaUtils
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.deleteAll
 import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 import org.jetbrains.exposed.sql.transactions.transaction
 
@@ -77,6 +78,10 @@ class FallbackDenylistService : DenylistService, Services.Fallback {
 
     override fun clearLocalEntries() {
         entries.clear()
+    }
+
+    override suspend fun clearEntries() = newSuspendedTransaction(Dispatchers.IO) {
+        DenylistTable.deleteAll()
     }
 
     override fun getLocalEntries(): ObjectList<DenylistEntry> {

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDiscordService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDiscordService.kt
@@ -71,7 +71,7 @@ class FallbackDiscordService : DiscordService, Services.Fallback {
         try {
             client.newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    error("Failed to send discord embed to $response")
+                    error("Failed to send discord embed: status=${response.code}, message=${response.message}")
                 }
             }
         } catch (e: Exception) {

--- a/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDiscordService.kt
+++ b/surf-chat-fallback/src/main/kotlin/dev/slne/surf/chat/fallback/service/FallbackDiscordService.kt
@@ -1,0 +1,81 @@
+package dev.slne.surf.chat.fallback.service
+
+import com.google.auto.service.AutoService
+import com.google.gson.Gson
+import dev.slne.surf.chat.api.entity.User
+import dev.slne.surf.chat.api.entry.DenylistEntry
+import dev.slne.surf.chat.core.service.DiscordService
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import net.kyori.adventure.util.Services
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@AutoService(DiscordService::class)
+class FallbackDiscordService : DiscordService, Services.Fallback {
+    private val client = OkHttpClient()
+    private val gson = Gson()
+
+    private data class EmbedField(
+        val name: String,
+        val value: String,
+        val inline: Boolean = false
+    )
+
+    private data class Embed(
+        val title: String,
+        val color: Int,
+        val fields: List<EmbedField>
+    )
+
+    private data class WebhookPayload(
+        val embeds: List<Embed>
+    )
+
+    override suspend fun sendCommunityBanNotification(
+        url: String,
+        user: User,
+        denylistEntry: DenylistEntry
+    ) = withContext(Dispatchers.IO) {
+        val timestamp = Instant.ofEpochMilli(denylistEntry.addedAt)
+            .atZone(ZoneId.systemDefault())
+            .format(DateTimeFormatter.RFC_1123_DATE_TIME)
+
+        val embed = Embed(
+            title = "Community Ban",
+            color = 0xFF0000,
+            fields = listOf(
+                EmbedField("User", "${user.name} (${user.uuid})", inline = true),
+                EmbedField("Reason", denylistEntry.reason),
+                EmbedField("Word Triggered", denylistEntry.word, inline = true),
+                EmbedField("Added By", denylistEntry.addedBy, inline = true),
+                EmbedField("Action", denylistEntry.action.name, inline = true),
+                EmbedField("Timestamp", timestamp)
+            )
+        )
+
+        val payload = WebhookPayload(listOf(embed))
+        val jsonPayload = gson.toJson(payload)
+        val requestBody =
+            jsonPayload.toRequestBody("application/json; charset=utf-8".toMediaType())
+        val request = Request.Builder()
+            .url(url)
+            .post(requestBody)
+            .build()
+
+        try {
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) {
+                    error("Failed to send discord embed to $response")
+                }
+            }
+        } catch (e: Exception) {
+            error("Error sending Discord webhook: ${e.message}")
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces several new features and improvements to the denylist system, expands moderation capabilities, and adds Discord integration support. The most significant changes are the addition of new denylist action types, new administrative commands for managing denylist entries and actions, and the introduction of a configurable Discord integration. These enhancements improve moderation flexibility and make it easier for administrators to manage chat behavior and integrate with external platforms.

**Denylist Actions & Command Enhancements**
* Added new denylist action types: `EXPIREABLE_BAN`, `PERMANENT_BAN`, and `COMMUNITY_BAN` to the `DenylistActionType` enum for more granular moderation options. [[1]](diffhunk://#diff-ae1c015e3ffe00d6ef9ed0b67086f3d113c59d74e3983732f850c2650b10736fL17-R26) [[2]](diffhunk://#diff-ae1c015e3ffe00d6ef9ed0b67086f3d113c59d74e3983732f850c2650b10736fL42-R62)
* Updated argument parsing and tab completion for denylist commands to support the new action types, and improved error messaging. [[1]](diffhunk://#diff-befea8a6e8086db962c80d4dfba0425bfb451406effbbe869f270a2c4dde3972L15-R23) [[2]](diffhunk://#diff-befea8a6e8086db962c80d4dfba0425bfb451406effbbe869f270a2c4dde3972L32-R36)
* Added `/denylist clear` and `/denylistaction clear` commands, allowing admins to clear all denylist entries and actions, respectively, with confirmation prompts. [[1]](diffhunk://#diff-ffdf3d42787e172f3b881715ff5d75b5d112173c20a2908500dbcbf25fc76b4dR1-R48) [[2]](diffhunk://#diff-e7a6bcbd84f9c07f5c11a92b95299a9e515cbb4becb9d0ee255f8ba425d56256R1-R49) [[3]](diffhunk://#diff-33102249a9253ed296054bb5aa5955c7cc1449214f357317ba04e1213ef32b3fR13-R14) [[4]](diffhunk://#diff-de0ec445958dad162d2ad50886cc7f343420e8bf14986268721243026b1155e3R13)
* Introduced `/denylist importdefaults` command for importing a batch of standard word filters with pre-defined actions and durations, including a disclaimer about sensitive language for moderation purposes. [[1]](diffhunk://#diff-37b4e427548809f545469ade8a7663a62b38d60cb91483fa1303c2ef00128b77R1-R127) [[2]](diffhunk://#diff-9f2aad86961006c7ba5141a9a64905dce74e1599a175e36bb26297bd1c9e07a4R48-R50)

**Discord Integration**
* Added `DiscordConfigProvider` and `DiscordConfig` to support loading and reloading Discord configuration from `discord.yml`, including enabling/disabling and setting a webhook URL. [[1]](diffhunk://#diff-54d70df5e28a64f6a84826dccfcf56d659d7bfc75d369bc947c88674ab7b471dR1-R28) [[2]](diffhunk://#diff-9720dea02b1d2b36b47500ffe668c74993abd7b10dd6fa1b29d974ca480b2829R1-R9) [[3]](diffhunk://#diff-81ec67249dbae3387f127c8c67fafdd6432b35d175b11d40195d292456faf306R6) [[4]](diffhunk://#diff-81ec67249dbae3387f127c8c67fafdd6432b35d175b11d40195d292456faf306R48) [[5]](diffhunk://#diff-74afe7d7442510d9d9e40377b08a52752c17858650258841ea527f4778022464R18)
* Updated `AsyncChatListener` to optionally include the Discord webhook in moderation actions if Discord integration is enabled.

**Build & Dependency Adjustments**
* Changed `MiniPlaceholders` server dependency registration to use `registerSoft` for optional loading and added `withCloudCommon()` to plugin configuration. [[1]](diffhunk://#diff-8eb7c3c26ffd52848ef80b857342000f1e7db70d1bc175c6031a2bfe001b013bR1-R2) [[2]](diffhunk://#diff-8eb7c3c26ffd52848ef80b857342000f1e7db70d1bc175c6031a2bfe001b013bR24-R27)

**Version Update**
* Updated project version to `1.21.8-4.0.3-SNAPSHOT` in `gradle.properties`.