### PR TITLE
feat: update denylist default entries

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.2.0" />
+    <option name="version" value="2.2.20" />
   </component>
 </project>

--- a/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
+++ b/surf-chat-bukkit/src/main/kotlin/dev/slne/surf/chat/bukkit/command/denylist/DenylistImportDefaultCommand.kt
@@ -50,19 +50,6 @@ fun CommandAPICommand.denylistImportDefaultCommand() = subcommand("importdefault
         plugin.launch(Dispatchers.IO) {
             listOf(
                 DenylistBatchEntry.builder()
-                    .withReason("Rassismus, Extremismus, Gewalt")
-                    .withStaff("Arty Support")
-                    .withActionType(DenylistActionType.COMMUNITY_BAN)
-                    .withPunishReason("Rassistische oder extremistische Inhalte")
-                    .withWords(
-                        "nigger",
-                        "ngga",
-                        "nigga",
-                        "hh",
-                        "heil hitler"
-                    )
-                    .build(),
-                DenylistBatchEntry.builder()
                     .withReason("Gewaltverherrlichende Inhalte")
                     .withStaff("Arty Support")
                     .withActionType(DenylistActionType.PERMANENT_BAN)
@@ -70,6 +57,11 @@ fun CommandAPICommand.denylistImportDefaultCommand() = subcommand("importdefault
                     .withWords(
                         "killyourself",
                         "kys",
+                        "nigger",
+                        "ngga",
+                        "nigga",
+                        "hh",
+                        "heil hitler"
                     )
                     .build(),
                 DenylistBatchEntry.builder()


### PR DESCRIPTION
This pull request updates the Kotlin compiler version and refactors how certain denylisted words are grouped in the default import command. The most important changes are grouped below:

Dependency update:

* Updated the Kotlin compiler version in `.idea/kotlinc.xml` from `2.2.0` to `2.2.20` to ensure compatibility with newer language features and bug fixes.

Denylist refactor:

* Removed the separate `DenylistBatchEntry` for words related to racism, extremism, and violence, and merged those words (`"nigger"`, `"ngga"`, `"nigga"`, `"hh"`, `"heil hitler"`) into the entry for glorification of violence in `DenylistImportDefaultCommand.kt`. This consolidates denylisted terms under a single action type and reason. [[1]](diffhunk://#diff-37b4e427548809f545469ade8a7663a62b38d60cb91483fa1303c2ef00128b77L52-L64) [[2]](diffhunk://#diff-37b4e427548809f545469ade8a7663a62b38d60cb91483fa1303c2ef00128b77R60-R64)