### PR TITLE
Add automatic suppression for connection messages during spikes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,107 +3,12 @@ name: Publish to Maven & Create GitHub Release
 on:
   push:
     branches:
-      - 'version/*'
-      - 'feat/microservice'
+      - version/*
   workflow_dispatch:
-
-env:
-  SLNE_SNAPSHOTS_REPO_USERNAME: ${{ secrets.SLNE_SNAPSHOTS_REPO_USERNAME }}
-  SLNE_SNAPSHOTS_REPO_PASSWORD: ${{ secrets.SLNE_SNAPSHOTS_REPO_PASSWORD }}
-  SLNE_RELEASES_REPO_USERNAME: ${{ secrets.SLNE_RELEASES_REPO_USERNAME }}
-  SLNE_RELEASES_REPO_PASSWORD: ${{ secrets.SLNE_RELEASES_REPO_PASSWORD }}
-  MODULE_REGEX: "surf-chat-paper.*-all\\.jar$|surf-chat-microservice.*-all\\.jar$"
-  DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
 jobs:
   build:
-    runs-on: self-hosted
-    steps:
-      - name: Collect Workflow Telemetry
-        uses: catchpoint/workflow-telemetry-action@v2
-
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: gradle-${{ runner.os }}-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: gradle-${{ runner.os }}-
-
-      - name: Setup JDK
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'graalvm'
-          java-version: '25'
-
-      - name: Build all modules with Gradle
-        run: ./gradlew build shadowJar --parallel --no-scan
-
-      - name: Publish all modules to Maven
-        run: ./gradlew publish --parallel --no-scan
-
-      - name: Extract Project Version and Snapshot Flag from Gradle
-        id: get_version
-        run: |
-          VERSION=$(./gradlew properties --no-daemon \
-            | grep '^version:' \
-            | awk '{print $2}')
-          SNAPSHOT_FLAG=$(./gradlew properties --no-daemon \
-            | grep '^snapshot:' \
-            | awk '{print $2}')
-          if [ "$SNAPSHOT_FLAG" = "true" ]; then
-            VERSION="${VERSION}-SNAPSHOT"
-          fi
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "SNAPSHOT_FLAG=$SNAPSHOT_FLAG" >> $GITHUB_ENV
-
-      - name: Determine release flags
-        run: |
-          CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
-          if [ "${SNAPSHOT_FLAG}" = "true" ]; then
-            echo "PRERELEASE=true" >> $GITHUB_ENV
-          else
-            echo "PRERELEASE=false" >> $GITHUB_ENV
-          fi
-          if [ "${SNAPSHOT_FLAG}" = "true" ] || [ "${CURRENT_BRANCH}" != "${DEFAULT_BRANCH}" ]; then
-            echo "MAKE_LATEST=false" >> $GITHUB_ENV
-          else
-            echo "MAKE_LATEST=true" >> $GITHUB_ENV
-          fi
-
-      - name: Set release title suffix
-        run: |
-          CURRENT_BRANCH=${GITHUB_REF#refs/heads/}
-          if [ "$CURRENT_BRANCH" = "feat/microservice" ]; then
-            echo "RELEASE_SUFFIX= (Microservice Based)" >> $GITHUB_ENV
-          else
-            echo "RELEASE_SUFFIX=" >> $GITHUB_ENV
-          fi
-
-      - name: Find and filter JAR files
-        id: find_jars
-        run: |
-          echo "JAR_FILES<<EOF" >> $GITHUB_ENV
-          find . -path "**/build/libs/*.jar" \
-            | grep -E "${{ env.MODULE_REGEX }}" \
-            >> $GITHUB_ENV
-          echo "EOF" >> $GITHUB_ENV
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ env.VERSION }}
-          name: Release ${{ env.VERSION }}${{ env.RELEASE_SUFFIX }}
-          draft: false
-          prerelease: ${{ env.PRERELEASE }}
-          make_latest: ${{ env.MAKE_LATEST }}
-          files: ${{ env.JAR_FILES }}
-          generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: SLNE-Development/surf-workflows/.github/workflows/build-publish-release-gradle.yml@master
+    with:
+      modules: "surf-chat-paper-*-all.jar;surf-chat-microservice-*-all.jar"
+    secrets: inherit

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=4.2.4-SNAPSHOT
+version=4.2.5

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/config/configs/ConnectionMessageConfig.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/config/configs/ConnectionMessageConfig.kt
@@ -14,12 +14,12 @@ data class ConnectionMessageConfig(
         "Players with the permission 'surf.chat.connection.always-show'\n" +
         "are exempt and their messages are always displayed."
     )
-    val autoDisableOnHighPlayerJoinThreshold: Boolean = true,
+    val autoDisableOnHighConnectionEventThreshold: Boolean = true,
 
     @field:Comment(
         "Maximum number of combined join and quit events per minute before\n" +
         "connection messages are suppressed automatically.\n" +
-        "Only relevant when 'autoDisableOnHighPlayerJoinThreshold' is true."
+        "Only relevant when 'autoDisableOnHighConnectionEventThreshold' is true."
     )
-    val joinsPerMinuteThreshold: Int = 15,
+    val connectionEventsPerMinuteThreshold: Int = 15,
 )

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/config/configs/ConnectionMessageConfig.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/config/configs/ConnectionMessageConfig.kt
@@ -1,8 +1,25 @@
 package dev.slne.surf.chat.paper.config.configs
 
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
+import org.spongepowered.configurate.objectmapping.meta.Comment
 
 @ConfigSerializable
 data class ConnectionMessageConfig(
-    val enabled: Boolean = true
+    @field:Comment("Whether join and quit messages are shown in chat at all.")
+    val enabled: Boolean = true,
+
+    @field:Comment(
+        "Automatically suppresses join and quit messages for regular players\n" +
+        "when too many connection events occur within one minute.\n" +
+        "Players with the permission 'surf.chat.connection.always-show'\n" +
+        "are exempt and their messages are always displayed."
+    )
+    val autoDisableOnHighPlayerJoinThreshold: Boolean = true,
+
+    @field:Comment(
+        "Maximum number of combined join and quit events per minute before\n" +
+        "connection messages are suppressed automatically.\n" +
+        "Only relevant when 'autoDisableOnHighPlayerJoinThreshold' is true."
+    )
+    val joinsPerMinuteThreshold: Int = 15,
 )

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/listener/ConnectListener.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/listener/ConnectListener.kt
@@ -7,9 +7,12 @@ import dev.slne.surf.chat.core.common.service.IgnoreService
 import dev.slne.surf.chat.paper.hook.LuckPermsHook
 import dev.slne.surf.chat.paper.hook.MiniPlaceholdersHook
 import dev.slne.surf.chat.paper.message.MessageFormatter
+import dev.slne.surf.chat.paper.permission.PermissionRegistry
 import dev.slne.surf.chat.paper.plugin
+import dev.slne.surf.chat.paper.service.ConnectionMessageService
 import io.papermc.paper.event.connection.configuration.AsyncPlayerConnectionConfigureEvent
 import kotlinx.coroutines.runBlocking
+import net.kyori.adventure.text.Component
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerJoinEvent
@@ -27,15 +30,13 @@ object ConnectListener : Listener {
 
     @EventHandler
     fun onPlayerJoin(event: PlayerJoinEvent) {
-        if (plugin.connectionMessageConfig.enabled) {
-            event.joinMessage(
-                buildText {
-                    darkSpacer("[")
-                    success("+")
-                    darkSpacer("] ")
-                    append(miniMessage.deserialize(LuckPermsHook.getPrefix(event.player) + event.player.name))
-                }
-            )
+        ConnectionMessageService.recordEvent()
+
+        val alwaysShow = event.player.hasPermission(PermissionRegistry.CONNECTION_MESSAGE_ALWAYS_SHOW)
+        val shouldShowMessage = alwaysShow || ConnectionMessageService.shouldShowConnectionMessage()
+
+        if (shouldShowMessage) {
+            event.joinMessage(buildJoinMessage(event))
         } else {
             event.joinMessage(null)
         }
@@ -54,5 +55,12 @@ object ConnectListener : Listener {
                 )
             }
         }
+    }
+
+    private fun buildJoinMessage(event: PlayerJoinEvent): Component = buildText {
+        darkSpacer("[")
+        success("+")
+        darkSpacer("] ")
+        append(miniMessage.deserialize(LuckPermsHook.getPrefix(event.player) + event.player.name))
     }
 }

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/listener/DisconnectListener.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/listener/DisconnectListener.kt
@@ -8,7 +8,10 @@ import dev.slne.surf.chat.core.common.service.IgnoreService
 import dev.slne.surf.chat.core.common.service.SpyService
 import dev.slne.surf.chat.paper.hook.LuckPermsHook
 import dev.slne.surf.chat.paper.message.MessageFormatter
+import dev.slne.surf.chat.paper.permission.PermissionRegistry
 import dev.slne.surf.chat.paper.plugin
+import dev.slne.surf.chat.paper.service.ConnectionMessageService
+import net.kyori.adventure.text.Component
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
 import org.bukkit.event.player.PlayerQuitEvent
@@ -18,15 +21,13 @@ object DisconnectListener : Listener {
     fun onDisconnect(event: PlayerQuitEvent) {
         MessageFormatter.dirty = true
 
-        if (plugin.connectionMessageConfig.enabled) {
-            event.quitMessage(
-                buildText {
-                    darkSpacer("[")
-                    error("-")
-                    darkSpacer("] ")
-                    append(miniMessage.deserialize(LuckPermsHook.getPrefix(event.player) + event.player.name))
-                }
-            )
+        ConnectionMessageService.recordEvent()
+
+        val alwaysShow = event.player.hasPermission(PermissionRegistry.CONNECTION_MESSAGE_ALWAYS_SHOW)
+        val shouldShowMessage = alwaysShow || ConnectionMessageService.shouldShowConnectionMessage()
+
+        if (shouldShowMessage) {
+            event.quitMessage(buildQuitMessage(event))
         } else {
             event.quitMessage(null)
         }
@@ -39,5 +40,12 @@ object DisconnectListener : Listener {
             IgnoreService.cleanup(uuid)
             SpyService.cleanup(uuid)
         }
+    }
+
+    private fun buildQuitMessage(event: PlayerQuitEvent): Component = buildText {
+        darkSpacer("[")
+        error("-")
+        darkSpacer("] ")
+        append(miniMessage.deserialize(LuckPermsHook.getPrefix(event.player) + event.player.name))
     }
 }

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/permission/PermissionRegistry.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/permission/PermissionRegistry.kt
@@ -9,6 +9,8 @@ object PermissionRegistry : PermissionRegistry() {
 
     val BYPASS_DISABLING = create("$PREFIX.disabling.bypass")
     val BYPASS_FILTER = create("$PREFIX.bypass.filter")
+
+    val CONNECTION_MESSAGE_ALWAYS_SHOW = create("$PREFIX.connection.always-show")
     val BYPASS_SPY = create("$PREFIX.bypass.spy")
     val BYPASS_FUNCTIONALITY = create("$PREFIX.bypass.functionality")
 

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/service/ConnectionMessageService.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/service/ConnectionMessageService.kt
@@ -1,0 +1,97 @@
+package dev.slne.surf.chat.paper.service
+
+import dev.slne.surf.chat.paper.plugin
+import java.util.concurrent.ConcurrentLinkedDeque
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Service responsible for tracking recent player joins and quits in order to
+ * automatically disable connection messages during connection spikes.
+ *
+ * A sliding one-minute window is used to determine whether the configured
+ * threshold has been exceeded.
+ */
+object ConnectionMessageService {
+    /**
+     * Stores connection event timestamps in nanoseconds (joins + quits).
+     *
+     * Entries are ordered from oldest to newest.
+     */
+    private val joinTimestamps = ConcurrentLinkedDeque<Long>()
+
+    /**
+     * Cached amount of currently valid connection events inside the sliding time window.
+     *
+     * Using an [AtomicInteger] avoids the expensive O(n) `Deque.size` call.
+     */
+    private val joinCount = AtomicInteger(0)
+
+    /**
+     * Duration of the sliding rate-limit window.
+     */
+    private const val WINDOW_NANO = 60_000_000_000L // 1 minute
+
+    /**
+     * Records a player connection event (join or quit) and updates the current sliding window state.
+     */
+    fun recordEvent() {
+        val now = System.nanoTime()
+
+        joinTimestamps.addLast(now)
+        joinCount.incrementAndGet()
+
+        pruneOldTimestamps(now)
+    }
+
+    /**
+     * Returns whether the configured join threshold has been exceeded.
+     *
+     * Old timestamps are cleaned up before evaluating the threshold.
+     *
+     * @return `true` if the join rate exceeds the configured limit,
+     * otherwise `false`
+     */
+    fun isRateLimitExceeded(): Boolean {
+        val config = plugin.connectionMessageConfig
+        if (!config.autoDisableOnHighPlayerJoinThreshold) return false
+
+        pruneOldTimestamps(System.nanoTime())
+
+        return joinCount.get() >= config.joinsPerMinuteThreshold
+    }
+
+    /**
+     * Determines whether connection messages should currently be shown.
+     *
+     * Connection messages are hidden if:
+     * - the feature is disabled in the configuration
+     * - the join rate limit is exceeded
+     *
+     * @return `true` if connection messages should be displayed,
+     * otherwise `false`
+     */
+    fun shouldShowConnectionMessage(): Boolean {
+        val config = plugin.connectionMessageConfig
+        return config.enabled && !isRateLimitExceeded()
+    }
+
+    /**
+     * Removes timestamps that are outside the sliding one-minute window.
+     *
+     * Every removed timestamp also decrements the cached join counter.
+     *
+     * @param now the current timestamp in nanoseconds
+     */
+    private fun pruneOldTimestamps(now: Long) {
+        val cutoff = now - WINDOW_NANO
+
+        while (true) {
+            val first = joinTimestamps.peekFirst() ?: break
+            if (first >= cutoff) break
+
+            if (joinTimestamps.pollFirst() != null) {
+                joinCount.decrementAndGet()
+            }
+        }
+    }
+}

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/service/ConnectionMessageService.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/service/ConnectionMessageService.kt
@@ -1,63 +1,59 @@
 package dev.slne.surf.chat.paper.service
 
 import dev.slne.surf.chat.paper.plugin
-import java.util.concurrent.ConcurrentLinkedDeque
-import java.util.concurrent.atomic.AtomicInteger
+import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue
 
 /**
- * Service responsible for tracking recent player joins and quits in order to
+ * Service responsible for tracking recent player connection events in order to
  * automatically disable connection messages during connection spikes.
  *
  * A sliding one-minute window is used to determine whether the configured
- * threshold has been exceeded.
+ * threshold has been reached.
  */
 object ConnectionMessageService {
+    private val lock = Any()
+
     /**
-     * Stores connection event timestamps in nanoseconds (joins + quits).
+     * Stores connection event timestamps in nanoseconds.
      *
      * Entries are ordered from oldest to newest.
      */
-    private val joinTimestamps = ConcurrentLinkedDeque<Long>()
-
-    /**
-     * Cached amount of currently valid connection events inside the sliding time window.
-     *
-     * Using an [AtomicInteger] avoids the expensive O(n) `Deque.size` call.
-     */
-    private val joinCount = AtomicInteger(0)
+    private val eventTimestamps = LongArrayFIFOQueue()
 
     /**
      * Duration of the sliding rate-limit window.
      */
-    private const val WINDOW_NANO = 60_000_000_000L // 1 minute
+    private const val WINDOW_NANOS = 60_000_000_000L // 1 minute
 
     /**
-     * Records a player connection event (join or quit) and updates the current sliding window state.
+     * Records a player connection event and updates the current sliding window state.
      */
     fun recordEvent() {
         val now = System.nanoTime()
 
-        joinTimestamps.addLast(now)
-        joinCount.incrementAndGet()
-
-        pruneOldTimestamps(now)
+        synchronized(lock) {
+            eventTimestamps.enqueue(now)
+            pruneOldTimestamps(now)
+        }
     }
 
     /**
-     * Returns whether the configured join threshold has been exceeded.
+     * Returns whether connection messages should currently be suppressed because
+     * the configured threshold has been reached.
      *
      * Old timestamps are cleaned up before evaluating the threshold.
      *
-     * @return `true` if the join rate exceeds the configured limit,
-     * otherwise `false`
+     * @return `true` if the amount of recent connection events is at or above
+     * the configured threshold, otherwise `false`
      */
     fun isRateLimitExceeded(): Boolean {
         val config = plugin.connectionMessageConfig
         if (!config.autoDisableOnHighPlayerJoinThreshold) return false
 
-        pruneOldTimestamps(System.nanoTime())
-
-        return joinCount.get() >= config.joinsPerMinuteThreshold
+        return synchronized(lock) {
+            pruneOldTimestamps(System.nanoTime())
+            eventTimestamps.size() >= config.joinsPerMinuteThreshold
+        }
     }
 
     /**
@@ -65,7 +61,7 @@ object ConnectionMessageService {
      *
      * Connection messages are hidden if:
      * - the feature is disabled in the configuration
-     * - the join rate limit is exceeded
+     * - the connection event threshold has been reached
      *
      * @return `true` if connection messages should be displayed,
      * otherwise `false`
@@ -78,20 +74,13 @@ object ConnectionMessageService {
     /**
      * Removes timestamps that are outside the sliding one-minute window.
      *
-     * Every removed timestamp also decrements the cached join counter.
-     *
      * @param now the current timestamp in nanoseconds
      */
     private fun pruneOldTimestamps(now: Long) {
-        val cutoff = now - WINDOW_NANO
+        val cutoff = now - WINDOW_NANOS
 
-        while (true) {
-            val first = joinTimestamps.peekFirst() ?: break
-            if (first >= cutoff) break
-
-            if (joinTimestamps.pollFirst() != null) {
-                joinCount.decrementAndGet()
-            }
+        while (!eventTimestamps.isEmpty && eventTimestamps.firstLong() < cutoff) {
+            eventTimestamps.dequeueLong()
         }
     }
 }

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/service/ConnectionMessageService.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/service/ConnectionMessageService.kt
@@ -48,11 +48,11 @@ object ConnectionMessageService {
      */
     fun isRateLimitExceeded(): Boolean {
         val config = plugin.connectionMessageConfig
-        if (!config.autoDisableOnHighPlayerJoinThreshold) return false
+        if (!config.autoDisableOnHighConnectionEventThreshold) return false
 
         return synchronized(lock) {
             pruneOldTimestamps(System.nanoTime())
-            eventTimestamps.size() >= config.joinsPerMinuteThreshold
+            eventTimestamps.size() >= config.connectionEventsPerMinuteThreshold
         }
     }
 


### PR DESCRIPTION
This pull request introduces an automatic rate-limiting feature for connection (join/quit) messages in the chat, suppressing them during periods of high player activity. It also refactors the build and release workflow and bumps the project version. The main changes are grouped below.

**Connection message rate-limiting and configuration:**

* Added a new `ConnectionMessageService` to track recent player joins/quits and suppress connection messages when a configurable per-minute threshold is exceeded. Players with the `surf.chat.connection.always-show` permission are exempt. [[1]](diffhunk://#diff-0adfafeb1e53e3f09763fea4d8fec070128d53d2edc4c42b757bb080bb079a45R1-R97) [[2]](diffhunk://#diff-6c426d7e2cc74a38c824c8851a40e96bfd60f816ce574085043f7093caf302a4L30-R39) [[3]](diffhunk://#diff-45fe960a4c75dbbf426b739b2728625b9726e78675fd503dff3a7f7cd2d75b1eL21-R30) [[4]](diffhunk://#diff-c4b36417aefede4cdecaac0157539af31b3ec62ff5ccd5838e469ec32fa5e87aR4-R24) [[5]](diffhunk://#diff-601880e23b18052bb3e2e1d40d8a93534b7b9b7ad0a36c93058849946592021eR12-R13)
* Updated `ConnectionMessageConfig` to add `autoDisableOnHighPlayerJoinThreshold` and `joinsPerMinuteThreshold` options, with descriptive comments for each.
* Modified `ConnectListener` and `DisconnectListener` to use the new service and permission, ensuring connection messages are only shown when appropriate. [[1]](diffhunk://#diff-6c426d7e2cc74a38c824c8851a40e96bfd60f816ce574085043f7093caf302a4L30-R39) [[2]](diffhunk://#diff-45fe960a4c75dbbf426b739b2728625b9726e78675fd503dff3a7f7cd2d75b1eL21-R30)
* Added helper methods for building join/quit messages and registered the new permission in `PermissionRegistry`. [[1]](diffhunk://#diff-6c426d7e2cc74a38c824c8851a40e96bfd60f816ce574085043f7093caf302a4R59-R65) [[2]](diffhunk://#diff-45fe960a4c75dbbf426b739b2728625b9726e78675fd503dff3a7f7cd2d75b1eR44-R50) [[3]](diffhunk://#diff-601880e23b18052bb3e2e1d40d8a93534b7b9b7ad0a36c93058849946592021eR12-R13)

**Build and release workflow:**

* Replaced the custom Gradle build/release workflow in `.github/workflows/publish.yml` with a reusable workflow from `SLNE-Development/surf-workflows`, simplifying CI/CD setup.

**Version update:**

* Bumped the project version from `4.2.4-SNAPSHOT` to `4.2.5`.