### PR TITLE
Improve AI moderation safety and configurability

### DIFF
--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/ai/OpenAiService.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/ai/OpenAiService.kt
@@ -5,12 +5,11 @@ import com.openai.client.okhttp.OpenAIOkHttpClientAsync
 import com.openai.models.moderations.Moderation
 import com.openai.models.moderations.ModerationCreateParams
 import com.sksamuel.aedile.core.asLoadingCache
-import dev.slne.surf.api.core.util.emptyObject2DoubleMap
+import dev.slne.surf.chat.paper.config.AiModerationThresholds
 import dev.slne.surf.chat.paper.config.aiModerationConfig
 import it.unimi.dsi.fastutil.objects.Object2DoubleMap
 import it.unimi.dsi.fastutil.objects.Object2DoubleOpenHashMap
 import kotlinx.coroutines.future.await
-import java.util.*
 import kotlin.time.Duration.Companion.hours
 import kotlin.time.toJavaDuration
 
@@ -19,18 +18,56 @@ val openAiService = OpenAiService()
 class OpenAiService {
     private val client = OpenAIOkHttpClientAsync.builder().apiKey(aiModerationConfig.apiKey).build()
 
-    private val resultCache = Caffeine
+    private val scoreCache = Caffeine
         .newBuilder()
         .expireAfterWrite(3.hours.toJavaDuration())
-        .asLoadingCache<String, ClassificationResult> {
-            classifyChatMessage0(it)
+        .asLoadingCache<ModerationInput, Object2DoubleMap<Category>> {
+            fetchCategoryScores(it)
         }
 
-    suspend fun classifyChatMessage(message: String): ClassificationResult = resultCache.get(message)
+    suspend fun classifyChatMessage(
+        message: String,
+        messageType: String
+    ): ClassificationResult {
+        val config = aiModerationConfig
+        val categoryScores = scoreCache.get(
+            ModerationInput(
+                model = config.model,
+                message = message,
+                messageType = messageType
+            )
+        )
+        val matchedScores = Object2DoubleOpenHashMap<Category>()
 
-    private suspend fun classifyChatMessage0(message: String): ClassificationResult {
+        for (category in Category.entries) {
+            val threshold = category.threshold(config.thresholds) ?: continue
+            val score = categoryScores.getDouble(category)
+
+            if (score >= threshold.coerceIn(0.0, 1.0)) {
+                matchedScores.put(category, score)
+            }
+        }
+
+        val action = matchedScores.keys
+            .maxByOrNull { it.action.ordinal }
+            ?.action
+            ?: ClassificationAction.NONE
+
+        return ClassificationResult(action, matchedScores, categoryScores)
+    }
+
+    private suspend fun fetchCategoryScores(
+        input: ModerationInput
+    ): Object2DoubleMap<Category> {
         val params = ModerationCreateParams.builder()
-            .input("[GAME_CHAT: MINECRAFT]\n$message")
+            .model(input.model)
+            .input(
+                buildString {
+                    appendLine("[GAME_CHAT: MINECRAFT]")
+                    appendLine("[MESSAGE_TYPE: ${input.messageType}]")
+                    append(input.message)
+                }
+            )
             .build()
 
         val result = client.moderations()
@@ -39,115 +76,80 @@ class OpenAiService {
             .results()
             .single()
 
-        val flaggedCategoryScores =
-            Category.categoriesByCategories(result.categories(), result.categoryScores())
-
-        if (!result.flagged()) {
-            return ClassificationResult(
-                ClassificationAction.NONE,
-                emptyObject2DoubleMap()
-            )
-        }
-
-        return ClassificationResult(decideAction(flaggedCategoryScores.keys), flaggedCategoryScores)
+        return Category.categoryScores(result.categoryScores())
     }
+
+    private data class ModerationInput(
+        val model: String,
+        val message: String,
+        val messageType: String
+    )
 
     data class ClassificationResult(
         val action: ClassificationAction,
-        val flaggedScores: Object2DoubleMap<Category>
+        val matchedScores: Object2DoubleMap<Category>,
+        val categoryScores: Object2DoubleMap<Category>
     )
 
-    private fun decideAction(categories: Set<Category>): ClassificationAction {
-        for (action in ClassificationAction.reversedEntries) {
-            if (action.categories.any { categories.contains(it) }) return action
-        }
-
-        return ClassificationAction.NONE
+    enum class ClassificationAction {
+        NONE,
+        SILENT_FLAG,
+        DELETE,
+        SEVERE
     }
 
-    enum class ClassificationAction(vararg categories: Category) {
-        NONE(
-            Category.VIOLENCE
-        ),
-        SILENT_FLAG(
-            Category.ILLICIT,
-            Category.ILLICIT_VIOLENT,
-            Category.SELF_HARM,
-            Category.SELF_HARM_INSTRUCTIONS,
-            Category.SELF_HARM_INTENT,
-        ),
-        DELETE(
-            Category.HARASSMENT,
-            Category.HARASSMENT_THREATENING,
-            Category.HATE,
-            Category.SEXUAL,
-            Category.VIOLENCE_GRAPHIC
-        ),
-        MUTE(Category.SEXUAL_MINORS, Category.HATE_THREATENING);
+    enum class Category(val action: ClassificationAction) {
+        HARASSMENT(ClassificationAction.DELETE),
+        HARASSMENT_THREATENING(ClassificationAction.DELETE),
+        HATE(ClassificationAction.DELETE),
+        HATE_THREATENING(ClassificationAction.SEVERE),
+        ILLICIT(ClassificationAction.SILENT_FLAG),
+        ILLICIT_VIOLENT(ClassificationAction.SILENT_FLAG),
+        SELF_HARM(ClassificationAction.SILENT_FLAG),
+        SELF_HARM_INSTRUCTIONS(ClassificationAction.SILENT_FLAG),
+        SELF_HARM_INTENT(ClassificationAction.SILENT_FLAG),
+        SEXUAL(ClassificationAction.DELETE),
+        SEXUAL_MINORS(ClassificationAction.SEVERE),
+        VIOLENCE(ClassificationAction.NONE),
+        VIOLENCE_GRAPHIC(ClassificationAction.DELETE);
 
-        val categories: EnumSet<Category> = EnumSet.copyOf(categories.toSet())
-
-        companion object {
-            val reversedEntries = entries.reversed()
+        fun threshold(thresholds: AiModerationThresholds): Double? = when (this) {
+            HARASSMENT -> thresholds.harassment
+            HARASSMENT_THREATENING -> thresholds.harassmentThreatening
+            HATE -> thresholds.hate
+            HATE_THREATENING -> thresholds.hateThreatening
+            ILLICIT -> thresholds.illicit
+            ILLICIT_VIOLENT -> thresholds.illicitViolent
+            SELF_HARM -> thresholds.selfHarm
+            SELF_HARM_INSTRUCTIONS -> thresholds.selfHarmInstructions
+            SELF_HARM_INTENT -> thresholds.selfHarmIntent
+            SEXUAL -> thresholds.sexual
+            SEXUAL_MINORS -> thresholds.sexualMinors
+            VIOLENCE -> null
+            VIOLENCE_GRAPHIC -> thresholds.violenceGraphic
         }
-    }
-
-    enum class Category {
-        HARASSMENT,
-        HARASSMENT_THREATENING,
-        HATE,
-        HATE_THREATENING,
-        ILLICIT,
-        ILLICIT_VIOLENT,
-        SELF_HARM,
-        SELF_HARM_INSTRUCTIONS,
-        SELF_HARM_INTENT,
-        SEXUAL,
-        SEXUAL_MINORS,
-        VIOLENCE,
-        VIOLENCE_GRAPHIC;
 
         companion object {
-            fun categoriesByCategories(
-                categories: Moderation.Categories,
+            fun categoryScores(
                 scores: Moderation.CategoryScores
             ): Object2DoubleMap<Category> {
-                val map = Object2DoubleOpenHashMap<Category>()
+                val map = Object2DoubleOpenHashMap<Category>(entries.size)
 
-                if (categories.harassment()) map.put(HARASSMENT, scores.harassment())
-                if (categories.harassmentThreatening()) map.put(
-                    HARASSMENT_THREATENING,
-                    scores.harassmentThreatening()
-                )
-                if (categories.hate()) map.put(HATE, scores.hate())
-                if (categories.hateThreatening()) map.put(
-                    HATE_THREATENING,
-                    scores.hateThreatening()
-                )
-                categories.illicit().ifTrue { map.put(ILLICIT, scores.illicit()) }
-                categories.illicitViolent()
-                    .ifTrue { map.put(ILLICIT_VIOLENT, scores.illicitViolent()) }
-                if (categories.selfHarm()) map.put(SELF_HARM, scores.selfHarm())
-                if (categories.selfHarmInstructions()) map.put(
-                    SELF_HARM_INSTRUCTIONS,
-                    scores.selfHarmInstructions()
-                )
-                if (categories.selfHarmIntent()) map.put(SELF_HARM_INTENT, scores.selfHarmIntent())
-                if (categories.sexual()) map.put(SEXUAL, scores.sexual())
-                if (categories.sexualMinors()) map.put(SEXUAL_MINORS, scores.sexualMinors())
-                if (categories.violence()) map.put(VIOLENCE, scores.violence())
-                if (categories.violenceGraphic()) map.put(
-                    VIOLENCE_GRAPHIC,
-                    scores.violenceGraphic()
-                )
+                map.put(HARASSMENT, scores.harassment())
+                map.put(HARASSMENT_THREATENING, scores.harassmentThreatening())
+                map.put(HATE, scores.hate())
+                map.put(HATE_THREATENING, scores.hateThreatening())
+                map.put(ILLICIT, scores.illicit())
+                map.put(ILLICIT_VIOLENT, scores.illicitViolent())
+                map.put(SELF_HARM, scores.selfHarm())
+                map.put(SELF_HARM_INSTRUCTIONS, scores.selfHarmInstructions())
+                map.put(SELF_HARM_INTENT, scores.selfHarmIntent())
+                map.put(SEXUAL, scores.sexual())
+                map.put(SEXUAL_MINORS, scores.sexualMinors())
+                map.put(VIOLENCE, scores.violence())
+                map.put(VIOLENCE_GRAPHIC, scores.violenceGraphic())
 
                 return map
-            }
-
-            private inline fun Optional<Boolean>.ifTrue(action: () -> Unit) {
-                if (this.orElse(false)) {
-                    action()
-                }
             }
         }
     }

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/config/AiModerationConfig.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/config/AiModerationConfig.kt
@@ -12,7 +12,11 @@ data class AiModerationConfig(
     val webhookUrl: String = "",
     val webhookAvatarUrl: String = "https://i.imgur.com/4vEeYfH.png",
     val userPanelPrefix: String = "https://support.castcrafter.de/cloud/cloud-players/",
-    val apiKey: String = ""
+    val apiKey: String = "",
+    val model: String = "omni-moderation-latest",
+    val autoMuteEnabled: Boolean = false,
+    val autoMuteDurationDays: Long = 7,
+    val thresholds: AiModerationThresholds = AiModerationThresholds()
 ) {
 
     companion object {
@@ -38,5 +42,21 @@ data class AiModerationConfig(
         fun init() = Unit
     }
 }
+
+@ConfigSerializable
+data class AiModerationThresholds(
+    val harassment: Double = 0.85,
+    val harassmentThreatening: Double = 0.90,
+    val hate: Double = 0.90,
+    val hateThreatening: Double = 0.97,
+    val illicit: Double = 0.85,
+    val illicitViolent: Double = 0.90,
+    val selfHarm: Double = 0.90,
+    val selfHarmInstructions: Double = 0.90,
+    val selfHarmIntent: Double = 0.90,
+    val sexual: Double = 0.92,
+    val sexualMinors: Double = 0.98,
+    val violenceGraphic: Double = 0.95
+)
 
 val aiModerationConfig get() = AiModerationConfig.getConfig()

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/processor/post/AiModerationPostChatProcessor.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/processor/post/AiModerationPostChatProcessor.kt
@@ -20,6 +20,7 @@ import dev.slne.surf.chat.paper.util.appendBotIcon
 import dev.slne.surf.chat.paper.util.hasPermission
 import dev.slne.surf.punish.api.common.punishment.PunishType
 import dev.slne.surf.punish.api.common.user.PunishmentUser
+import it.unimi.dsi.fastutil.objects.Object2DoubleMap
 import net.kyori.adventure.text.event.ClickEvent
 import org.bukkit.Bukkit
 import java.awt.Color
@@ -65,8 +66,19 @@ object AiModerationPostChatProcessor : PostChatProcessor {
                             content("Die Chat Nachricht wurde gelöscht.")
                         }
 
-                        OpenAiService.ClassificationAction.MUTE -> {
-                            content("Die Chat Nachricht wurde gelöscht und der Absender wurde für 7 Tage stumm geschaltet — bitte überprüfen")
+                        OpenAiService.ClassificationAction.SEVERE -> {
+                            if (aiModerationConfig.autoMuteEnabled) {
+                                content(
+                                    "Die Chat Nachricht wurde gelöscht und der Absender wurde für " +
+                                        "${aiModerationConfig.autoMuteDurationDays.coerceAtLeast(1)} Tage " +
+                                        "stumm geschaltet — bitte überprüfen"
+                                )
+                            } else {
+                                content(
+                                    "Die Chat Nachricht wurde gelöscht und als schwerwiegend markiert — " +
+                                        "bitte zeitnah überprüfen"
+                                )
+                            }
                         }
 
                         else -> Unit
@@ -76,7 +88,7 @@ object AiModerationPostChatProcessor : PostChatProcessor {
                         when (classification.action) {
                             OpenAiService.ClassificationAction.SILENT_FLAG -> Color.YELLOW
                             OpenAiService.ClassificationAction.DELETE -> Color.RED
-                            OpenAiService.ClassificationAction.MUTE -> Color.MAGENTA
+                            OpenAiService.ClassificationAction.SEVERE -> Color.MAGENTA
                             else -> Color.WHITE
                         }
                     )
@@ -88,19 +100,14 @@ object AiModerationPostChatProcessor : PostChatProcessor {
                     }
 
                     field {
-                        name("Kategorien")
-                        value(buildString {
-                            classification.flaggedScores.object2DoubleEntrySet()
-                                .sortedByDescending { it.doubleValue }
-                                .forEachIndexed { index, entry ->
-                                    val category = entry.key
-                                    val scorePercent = entry.doubleValue * 100
-                                    append("- ${category.name} (${"%.2f".format(scorePercent)} %)")
-                                    if (index != classification.flaggedScores.size - 1) {
-                                        append("\n")
-                                    }
-                                }
-                        })
+                        name("Auslösende Kategorien")
+                        value(formatScores(classification.matchedScores))
+                        inline = false
+                    }
+
+                    field {
+                        name("Höchste Modellwerte")
+                        value(formatScores(classification.categoryScores, limit = 5))
                         inline = false
                     }
 
@@ -137,10 +144,20 @@ object AiModerationPostChatProcessor : PostChatProcessor {
         }
     }
 
+    private fun formatScores(
+        scores: Object2DoubleMap<OpenAiService.Category>,
+        limit: Int = Int.MAX_VALUE
+    ): String = scores.object2DoubleEntrySet()
+        .sortedByDescending { it.doubleValue }
+        .take(limit)
+        .joinToString("\n") { entry ->
+            val scorePercent = entry.doubleValue * 100
+            "- ${entry.key.name} (${"%.2f".format(scorePercent)} %)"
+        }
+
     private fun nameOrUuid(uuid: UUID): String {
         return Bukkit.getOfflinePlayer(uuid).name ?: uuid.toString()
     }
-
 
     suspend fun processMessage(messageData: MessageData) {
         if (messageData.sender.hasPermission(PermissionRegistry.BYPASS_FILTER)) {
@@ -148,7 +165,7 @@ object AiModerationPostChatProcessor : PostChatProcessor {
         }
 
         val plain = messageData.plainMessage
-        val classification = openAiService.classifyChatMessage(plain)
+        val classification = openAiService.classifyChatMessage(plain, messageData.type.value)
 
         if (classification.action == OpenAiService.ClassificationAction.NONE) {
             return
@@ -164,7 +181,7 @@ object AiModerationPostChatProcessor : PostChatProcessor {
                     appendBotIcon()
                     info("Die Nachricht von ")
                     variableValue(name)
-                    info(" wurde als bedrohlich eingestuft: ")
+                    info(" wurde von der KI-Moderation markiert: ")
                     spacer("(${messageData.type.value}) ")
 
                     append {
@@ -178,7 +195,7 @@ object AiModerationPostChatProcessor : PostChatProcessor {
                         })
                     }
 
-                    if (classification.action != OpenAiService.ClassificationAction.DELETE) {
+                    if (classification.action == OpenAiService.ClassificationAction.SILENT_FLAG) {
                         append {
                             spacer(" [")
                             text("LÖSCHEN", Colors.RED)
@@ -212,38 +229,56 @@ object AiModerationPostChatProcessor : PostChatProcessor {
 
         when (classification.action) {
             OpenAiService.ClassificationAction.DELETE -> {
-                DeletionService.deleteMessage(
-                    messageData,
-                    deletionReason = "AI classification: ${classification.action.name}",
-                )
+                deleteMessage(messageData, classification.action)
             }
 
-            OpenAiService.ClassificationAction.MUTE -> {
-                val sender = messageData.sender
-                val note = buildString {
-                    append("[AI MODERATION] Unangemessenes Chat verhalten: [")
-                    val scores = classification.flaggedScores.object2DoubleEntrySet()
-                        .sortedByDescending { it.doubleValue }
+            OpenAiService.ClassificationAction.SEVERE -> {
+                deleteMessage(messageData, classification.action)
 
-                    for (entry in scores) {
-                        val category = entry.key
-                        val scorePercent = entry.doubleValue * 100
-                        append("${category.name}=${"%.2f".format(scorePercent)} %")
-                        if (entry != scores.last()) {
-                            append(", ")
-                        }
-                    }
-
-                    append("]")
+                if (aiModerationConfig.autoMuteEnabled) {
+                    mutePlayer(messageData, classification)
                 }
-
-                PunishmentUser.byUuid(sender)
-                    .punish(PunishType.MUTE.Expirable(OffsetDateTime.now().plusDays(7)) {
-                        note(note)
-                    }, "Unangemessenes Chat verhalten")
             }
 
             else -> Unit
         }
+    }
+
+    private suspend fun deleteMessage(
+        messageData: MessageData,
+        action: OpenAiService.ClassificationAction
+    ) {
+        DeletionService.deleteMessage(
+            messageData,
+            deletionReason = "AI classification: ${action.name}",
+        )
+    }
+
+    private suspend fun mutePlayer(
+        messageData: MessageData,
+        classification: OpenAiService.ClassificationResult
+    ) {
+        val sender = messageData.sender
+        val durationDays = aiModerationConfig.autoMuteDurationDays.coerceAtLeast(1)
+        val note = buildString {
+            append("[AI MODERATION] Schwerwiegendes Chatverhalten: [")
+            val scores = classification.matchedScores.object2DoubleEntrySet()
+                .sortedByDescending { it.doubleValue }
+
+            for (entry in scores) {
+                val scorePercent = entry.doubleValue * 100
+                append("${entry.key.name}=${"%.2f".format(scorePercent)} %")
+                if (entry != scores.last()) {
+                    append(", ")
+                }
+            }
+
+            append("]")
+        }
+
+        PunishmentUser.byUuid(sender)
+            .punish(PunishType.MUTE.Expirable(OffsetDateTime.now().plusDays(durationDays)) {
+                note(note)
+            }, "Schwerwiegendes unangemessenes Chatverhalten")
     }
 }


### PR DESCRIPTION
## What changed

- explicitly configure the OpenAI moderation model, defaulting to `omni-moderation-latest`
- evaluate all returned category scores against configurable Surf-specific thresholds
- include the message type in the moderation input
- separate severe classifications from automatic punishment
- disable automatic mutes by default while keeping them configurable
- always delete severe messages before any optional mute is applied
- show both threshold-triggering categories and the highest raw model scores in the webhook
- only show the manual delete action for messages that were not already deleted automatically

## Why

The previous implementation relied entirely on OpenAI's global `flagged` booleans and could issue a seven-day mute from a single classification. It also did not delete messages handled by the old `MUTE` action even though the webhook claimed that it did.

This change makes moderation decisions explicit, tunable for Minecraft chat, and safer against false positives while preserving automatic deletion for high-confidence harmful content.

## Validation

- compared the branch against `version/26.1`
- verified that only the AI moderation service, configuration, and post-processor are changed

A full Gradle build could not be run in the connector environment, so this PR is opened as a draft for CI and review.