### PR TITLE
✨ feat(redis): add cache expiration for moderation and chat messages

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=4.5.5
+version=4.5.6

--- a/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/redis/ModerationRedisService.kt
+++ b/surf-chat-paper/src/main/kotlin/dev/slne/surf/chat/paper/redis/ModerationRedisService.kt
@@ -6,6 +6,7 @@ import dev.slne.surf.chat.core.common.aimoderation.ModerationClassificationResul
 import dev.slne.surf.chat.core.paper.redisApi
 import dev.slne.surf.redis.codec.JsonKotlinCodec
 import kotlinx.serialization.Serializable
+import java.util.concurrent.TimeUnit
 
 object ModerationRedisService {
     private val log = logger()
@@ -25,16 +26,17 @@ object ModerationRedisService {
     }
 
     fun cache(messageData: MessageData, classificationResult: ModerationClassificationResult) {
-        moderationCache.addAsync(ModerationCacheEntry(messageData, classificationResult)).exceptionally { throwable ->
-            log.atWarning()
-                .withCause(throwable)
-                .log("Failed to cache moderation result for message ${messageData.messageUuid}")
-            null
-        }
+        moderationCache.addAsync(ModerationCacheEntry(messageData, classificationResult), 1, TimeUnit.HOURS)
+            .exceptionally { throwable ->
+                log.atWarning()
+                    .withCause(throwable)
+                    .log("Failed to cache moderation result for message ${messageData.messageUuid}")
+                null
+            }
     }
 
     fun cache(messageData: MessageData) {
-        chatMessageCache.addAsync(messageData).exceptionally { throwable ->
+        chatMessageCache.addAsync(messageData, 1, TimeUnit.HOURS).exceptionally { throwable ->
             log.atWarning()
                 .withCause(throwable)
                 .log("Failed to cache message ${messageData.messageUuid}")


### PR DESCRIPTION
- set cache expiration to 1 hour for moderation results and chat messages
- enhance error handling during cache operations